### PR TITLE
Add on_process event to Consumer

### DIFF
--- a/insights_messaging/consumers/__init__.py
+++ b/insights_messaging/consumers/__init__.py
@@ -28,8 +28,9 @@ class Consumer(Watched):
 
                 broker = self.create_broker(input_msg)
                 results = self.engine.process(broker, path)
-                self.publisher.publish(input_msg, results)
+                self.fire("on_process", input_msg, results)
 
+                self.publisher.publish(input_msg, results)
                 self.fire("on_consumer_success", input_msg, broker, results)
         except Exception as ex:
             self.publisher.error(input_msg, ex)

--- a/insights_messaging/watchers/__init__.py
+++ b/insights_messaging/watchers/__init__.py
@@ -64,12 +64,17 @@ class EngineWatcher(Watcher):
 class ConsumerWatcher(Watcher):
     def on_recv(self, input_msg):
         """
-        Fired after the consumer recieves a message to process.
+        Fired after the consumer receives a message to process.
         """
 
     def on_download(self, path):
         """
         Fired after the consumer downloads an archive to path.
+        """
+
+    def on_process(self, input_msg, results):
+        """
+        Fired after the consumer finishes processing downloaded data.
         """
 
     def on_consumer_success(self, input_msg, broker, results):


### PR DESCRIPTION
We want to be able to log the duration of processing separate from the duration of publishing over at `/ccx-data-pipeline`.