### PR TITLE
[WIP] Adding support for configuring a memory limit for extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ will use `/tmp` if no path is provided.
 an archive. It raises an exception if the timeout is exceeded or tries forever
 if no timeout is specified.
 
+`extract_memory_limit` is the limit of virtual memory bytes that the extraction
+of an archive can take. It raises an exception if the memory limit is exceeded.
+
 
 ```yaml
 # insights.parsers.redhat_release must be loaded and enabled for
@@ -179,6 +182,7 @@ configs:
       enabled: true
 service:
     extract_timeout: 10
+    extract_memory_limit: 100000000
     extract_tmp_dir: ${TMP_DIR:/tmp}
     format: insights_stats_worker.rhel_stats.Stats
     target_components:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -13,6 +13,7 @@ configs:
       enabled: true
 service:
     extract_timeout:
+    extract_memory_limit:
     extract_tmp_dir:
     format: insights.formats._json.JsonFormat
     target_components:

--- a/insights_messaging/appbuilder.py
+++ b/insights_messaging/appbuilder.py
@@ -110,6 +110,9 @@ class AppBuilder:
     def _get_extract_timeout(self):
         return self.service.get("extract_timeout")
 
+    def _get_extract_memory_limit(self):
+        return self.service.get("extract_memory_limit")
+
     def _get_extract_tmp_dir(self):
         return self.service.get("extract_tmp_dir")
 
@@ -131,8 +134,10 @@ class AppBuilder:
         publisher = self._get_publisher()
         downloader = self._get_downloader()
         timeout = self._get_extract_timeout()
+        memory_limit = self._get_extract_memory_limit()
         tmp_dir = self._get_extract_tmp_dir()
-        engine = Engine(target_components, self._get_format(), timeout=timeout, tmp_dir=tmp_dir)
+        engine = Engine(target_components, self._get_format(), timeout=timeout, memory_limit=memory_limit,
+                        tmp_dir=tmp_dir)
         consumer = self._get_consumer(publisher, downloader, engine)
 
         for w in self._get_watchers():

--- a/insights_messaging/engine.py
+++ b/insights_messaging/engine.py
@@ -1,3 +1,7 @@
+"""
+engine module contains the Engine class.
+"""
+
 import logging
 from io import StringIO
 from insights.core import dr
@@ -10,23 +14,26 @@ log = logging.getLogger(__name__)
 
 
 class Engine(Watched):
-    def __init__(self, comps=None, Format=Formatter, timeout=None, tmp_dir=None):
+    """Engine class encapsulates the usage of the insights library."""
+    def __init__(self, comps=None, Format=Formatter, timeout=None, memory_limit=None, tmp_dir=None):
+        """Engine constructor."""
         super().__init__()
         self.comps = comps
         self.Format = Format
         self.timeout = timeout
+        self.memory_limit = memory_limit
         self.tmp_dir = tmp_dir
 
     def process(self, broker, path):
+        """"""
         for w in self.watchers:
             w.watch_broker(broker)
-
-        result = None
 
         try:
             self.fire("pre_extract", broker, path)
 
-            with extract(path, timeout=self.timeout, extract_dir=self.tmp_dir) as extraction:
+            with extract(path, timeout=self.timeout, memory_limit=self.memory_limit,
+                         extract_dir=self.tmp_dir) as extraction:
                 ctx = create_context(extraction.tmp_dir)
                 broker[ctx.__class__] = ctx
 

--- a/insights_messaging/tests/test_resolve_variables.py
+++ b/insights_messaging/tests/test_resolve_variables.py
@@ -11,6 +11,7 @@ plugins:
         - publishers
 service:
     extract_timeout: 10
+    extract_memory_limit: 100000
     extract_tmp_dir:
     consumer:
         name: consumers.process_report.ProcessReport
@@ -81,6 +82,7 @@ def test_resolve_variables():
     res = resolve_variables(CONF)
     assert res["plugins"]["default_component_enabled"] is True
     assert res["service"]["extract_timeout"] == 10
+    assert res["service"]["extract_memory_limit"] == 100000
     assert res["service"]["consumer"]["kwargs"]["bootstrap_server"] == "$BOOTSTRAP_URL"
     assert res["service"]["consumer"]["kwargs"]["security_protocol"] == "SSL"
     assert res["service"]["consumer"]["kwargs"]["ssl_cafile"] == "/mnt/cert.crt"


### PR DESCRIPTION
This commit will allow to specify a virtual memory limit for the archive extraction process. It will be helpful when malformed archives are received in the pipeline, so the subprocess won't take as much memory as it can

This PR depends on this `insights-core` one: https://github.com/RedHatInsights/insights-core/pull/2511 to be merged
