### PR TITLE
Use hostname for group.instance.id if configured

### DIFF
--- a/insights_messaging/consumers/kafka.py
+++ b/insights_messaging/consumers/kafka.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from confluent_kafka import Consumer as ConfluentConsumer
 from insights_messaging.consumers import Consumer
@@ -22,6 +23,7 @@ class Kafka(Consumer):
         config = kwargs.copy()
         config["group.id"] = group_id
         config["bootstrap.servers"] = ",".join(bootstrap_servers)
+        config["group.instance.id"] = kwargs.get("group.instance.id", os.environ.get("HOSTNAME")
         log.info("config", extra={"config": config})
 
         self.auto_commit = kwargs.get("enable.auto.commit", True)


### PR DESCRIPTION
We want to be able to use the static instance id feature of kafka so
that we can avoid unnecessary rebalances on the event of a consumer
crashing. This allows the consumer to come back up and get the same
partition it had previously so we don't pass around failed messages that
were not committed.

Signed-off-by: Stephen Adams <tsadams@gmail.com>