### PR TITLE
feat: allow multiple topic subscriptions

### DIFF
--- a/insights_messaging/consumers/kafka.py
+++ b/insights_messaging/consumers/kafka.py
@@ -27,8 +27,14 @@ class Kafka(Consumer):
         self.auto_commit = kwargs.get("enable.auto.commit", True)
         self.consumer = ConfluentConsumer(config)
 
-        self.consumer.subscribe([incoming_topic])
-        log.info("subscribing to %s: %s", incoming_topic, self.consumer)
+        if type(incoming_topic) == list:
+            self.consumer.subscribe(incoming_topic)
+            log.info("subscribing to topics with consumer %s", self.consumer)
+            for topic in incoming_topic:
+                log.info(" - %s", topic)
+        else:   
+            self.consumer.subscribe([incoming_topic])
+            log.info("subscribing to %s: %s", incoming_topic, self.consumer)
 
     def deserialize(self, bytes_):
         raise NotImplementedError()


### PR DESCRIPTION
We need to be able to just accept a list of topics instead of assuming
we're just passing a string into a list. Since consumers can subscribe
to multiple topics, we should probably prefer a list in the yaml as
well.

To not break any apps using the library currently, I went with an if
statement, but it would probably be best to figure out how to get this
to be the default behavior moving forward. 

Yaml would then look like:

```
    incoming_topics:
      - some.topic
      - some.other.topic
```

Signed-off-by: Stephen Adams <tsadams@gmail.com>