### PR TITLE
Requeue support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ class Interactive(Consumer):
         return input_msg
 ```
 
+Requeuer
+--------
+A requerer allows a consumer to raise a `Requeue` exception to indicate that
+it couldn't handle the input and would like the requerer to do something with
+it. What the requerer does is open ended: it could put the message onto a
+different topic, send it to a different message broker, store it in a
+database, etc.
+
+
 Publisher
 ---------
 A publisher stores results in some way. For example, it could publish them to
@@ -230,6 +239,13 @@ service:
             conn_params:
                 host: ${CONSUMER_HOST:localhost}
                 port: ${CONSUMER_PORT:5672}
+    requeuer:
+        name: example.requeuer.Requeuer
+        kwargs:
+            queue: retry
+            conn_params:
+                host: ${CONSUMER_HOST:localhost}
+                port: ${CONSUMER_PORT:5672}
     publisher:
         name: insights_messaging.publishers.rabbitmq.RabbitMQ
         kwargs:
@@ -250,7 +266,7 @@ service:
 ```
 
 Default Engine Config
---------------------
+---------------------
 ```yaml
 # insights.parsers.redhat_release must be loaded and enabled for
 # insights_messaging.formats.rhel_stats.Stats to collect product and version
@@ -275,6 +291,13 @@ service:
         name: insights_stats_worker.consumer.Consumer
         kwargs:
             queue: test_job
+            conn_params:
+                host: ${CONSUMER_HOST:localhost}
+                port: ${CONSUMER_PORT:5672}
+    requeuer:
+        name: example.requeuer.Requeuer
+        kwargs:
+            queue: retry
             conn_params:
                 host: ${CONSUMER_HOST:localhost}
                 port: ${CONSUMER_PORT:5672}

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -29,6 +29,8 @@ service:
         name: insights_messaging.downloaders.localfs.LocalFS
     watchers:
         - name: insights_messaging.watchers.stats.LocalStatWatcher
+    logging_configurator:
+        name: insights_messaging.tests.test_get_logging_config.custom_log_config
     logging:
         version: 1
         disable_existing_loggers: false

--- a/insights_messaging/appbuilder.py
+++ b/insights_messaging/appbuilder.py
@@ -56,7 +56,7 @@ class AppBuilder:
         kwargs = spec.get("kwargs", {})
         return comp(*args, **kwargs)
 
-    def _get_consumer(self, publisher, downloader, engine):
+    def _get_consumer(self, publisher, downloader, engine, requeuer):
         if "consumer" not in self.service:
             return Interactive(publisher, downloader, engine)
         spec = self.service["consumer"]
@@ -65,7 +65,11 @@ class AppBuilder:
             raise Exception(f"Couldn't find {spec['name']}.")
         args = spec.get("args", [])
         kwargs = spec.get("kwargs", {})
-        return Consumer(publisher, downloader, engine, *args, **kwargs)
+        return Consumer(publisher, downloader, engine, *args, requeuer=requeuer, **kwargs)
+
+    def _get_requeuer(self):
+        if "requeuer" in self.service:
+            return self._load(self.service["requeuer"])
 
     def _get_publisher(self):
         if "publisher" not in self.service:
@@ -138,7 +142,8 @@ class AppBuilder:
         downloader = self._get_downloader()
         engine = self._get_engine()
         publisher = self._get_publisher()
-        consumer = self._get_consumer(publisher, downloader, engine)
+        requeuer = self._get_requeuer()
+        consumer = self._get_consumer(publisher, downloader, engine, requeuer)
 
         for w in self._get_watchers():
             if isinstance(w, EngineWatcher):

--- a/insights_messaging/consumers/__init__.py
+++ b/insights_messaging/consumers/__init__.py
@@ -6,12 +6,19 @@ from insights_messaging.watchers import Watched
 log = logging.getLogger(__name__)
 
 
+class Requeue(Exception):
+    """
+    An Exception to mesasge a requeue request.
+    """
+
+
 class Consumer(Watched):
-    def __init__(self, publisher, downloader, engine):
+    def __init__(self, publisher, downloader, engine, requeuer=None):
         super().__init__()
         self.publisher = publisher
         self.downloader = downloader
         self.engine = engine
+        self.requerer = requeuer
 
     def run(self):
         raise NotImplementedError()

--- a/insights_messaging/consumers/kafka.py
+++ b/insights_messaging/consumers/kafka.py
@@ -59,10 +59,10 @@ class Kafka(Consumer):
                     payload = self.deserialize(val)
                     if self.handles(payload):
                         self.process(payload)
-                except Requeue:
+                except Requeue as req:
                     if not self.requerer:
                         raise Exception("Requeue request with no requerer configured.")
-                    self.requeuer.requeue(val)
+                    self.requeuer.requeue(val, req)
                 except Exception as ex:
                     log.exception(ex)
                 finally:

--- a/insights_messaging/requeuers/__init__.py
+++ b/insights_messaging/requeuers/__init__.py
@@ -1,0 +1,3 @@
+class Requeuer:
+    def requeue(self, msg):
+        pass

--- a/insights_messaging/requeuers/__init__.py
+++ b/insights_messaging/requeuers/__init__.py
@@ -1,3 +1,7 @@
 class Requeuer:
-    def requeue(self, msg):
+    def requeue(self, msg, req):
+        """
+        msg: the msg to requeue or otherwise handle
+        req: the Requeue exception that signaled the requeue request
+        """
         pass

--- a/insights_messaging/requeuers/kafka.py
+++ b/insights_messaging/requeuers/kafka.py
@@ -20,5 +20,5 @@ class KafkaRequeuer(Requeuer):
 
         self.producer = ConfluentProducer(config)
 
-    def requeue(self, msg):
+    def requeue(self, msg, req):
         self.producer.produce(self.topic, msg)

--- a/insights_messaging/requeuers/kafka.py
+++ b/insights_messaging/requeuers/kafka.py
@@ -1,0 +1,24 @@
+import logging
+
+from confluent_kafka import Producer as ConfluentProducer
+
+from . import Requeuer
+
+log = logging.getLogger(__name__)
+
+
+class KafkaRequeuer(Requeuer):
+    def __init__(self, topic, group_id, bootstrap_servers, **kwargs):
+        self.topic = topic
+        self.group_id = group_id
+        self.bootstrap_servers = bootstrap_servers
+
+        config = kwargs.copy()
+        config["group.id"] = group_id
+        config["bootstrap.servers"] = ",".join(bootstrap_servers)
+        log.info("config", extra={"config": config})
+
+        self.producer = ConfluentProducer(config)
+
+    def requeue(self, msg):
+        self.producer.produce(self.topic, msg)

--- a/insights_messaging/requeuers/rabbitmq.py
+++ b/insights_messaging/requeuers/rabbitmq.py
@@ -1,0 +1,46 @@
+import logging
+import pika
+from retry import retry
+from . import Requeuer
+
+log = logging.getLogger(__name__)
+
+
+class RabbitMQ(Requeuer):
+    def __init__(
+        self, queue, conn_params, exchange="", auth=None, durable=False,
+    ):
+        self.queue = queue
+        self.exchange = exchange
+        self.durable = durable
+        self.properties = (
+            pika.BasicProperties(delivery_mode=2) if self.durable else None
+        )
+
+        creds = None if auth is None else pika.credentials.PlainCredentials(**auth)
+        if creds is not None:
+            conn_params["credentials"] = creds
+        self.params = pika.ConnectionParameters(**conn_params)
+        self.open()
+
+    def open(self):
+        self.connection = pika.BlockingConnection(self.params)
+        self.channel = self.connection.channel()
+        self.channel.queue_declare(queue=self.queue, durable=self.durable)
+
+    def send(self, msg):
+        if not self.connection.is_open:
+            self.open()
+        self.channel.basic_publish(
+            exchange=self.exchange,
+            routing_key=self.queue,
+            properties=self.properties,
+            body=msg,
+        )
+
+    @retry(pika.exceptions.AMQPConnectionError, delay=1, jitter=(1, 3))
+    def requeue(self, msg):
+        try:
+            self.send(msg)
+        except pika.exceptions.ConnectionClosedByBroker:
+            pass


### PR DESCRIPTION
Allows a consumer to raise a `Requeue` exception to indicate that it couldn't handle the input and would like the requerer to do something with it. What the requerer does is open ended: it could put the message onto a different topic, send it to a different message broker, store it in a database, etc.