### PR TITLE
Add null downloader for skipping download step

### DIFF
--- a/insights_messaging/downloaders/null.py
+++ b/insights_messaging/downloaders/null.py
@@ -1,0 +1,7 @@
+from contextlib import contextmanager
+
+
+class NullDownloader:
+    @contextmanager
+    def get(self, src):
+        yield src  # Do nothing.  Defer to the extractor


### PR DESCRIPTION
In our current setup the file is downloaded from an s3 bucket to local network based storage.  This is a redundant step that can be removed. 

This change allows the extractor to directly extract from the s3 bucket.  i.e. `curl example.com/file.tar  | tar -x`

Example extractor change: https://github.com/dkuc/insights-core/pull/1