### PR TITLE
Use default components if no target components

### DIFF
--- a/insights_messaging/engine.py
+++ b/insights_messaging/engine.py
@@ -20,7 +20,7 @@ class Engine(Watched):
     ):
         super().__init__()
         self.Formatter = formatter or HumanReadableFormat
-        self.components_dict = dr.determine_components(target_components)
+        self.components_dict = dr.determine_components(target_components or dr.COMPONENTS[dr.GROUPS.single])
         self.target_components = dr.toposort_flatten(self.components_dict, sort=False)
         self.extract_timeout = extract_timeout
         self.extract_tmp_dir = extract_tmp_dir


### PR DESCRIPTION
The previous change didn't account for the absence of target components and so wouldn't run anything even if components were otherwise loaded. This PR fixes the behavior.

Signed-off-by: Christopher Sams <csams@redhat.com>