### PR TITLE
Add rebalance metrics for Kafka consumers

### DIFF
--- a/insights_messaging/consumers/kafka.py
+++ b/insights_messaging/consumers/kafka.py
@@ -80,6 +80,7 @@ class Kafka(Consumer):
         group_id,
         bootstrap_servers,
         requeuer=None,
+        metric_interval=10000,  # Gather metrics every 10 secs by default
         **kwargs
     ):
 
@@ -90,7 +91,7 @@ class Kafka(Consumer):
         config["bootstrap.servers"] = ",".join(bootstrap_servers)
         config["group.instance.id"] = kwargs.get("group.instance.id", os.environ.get("HOSTNAME"))
         config["stats_cb"] = self.metrics_collector.stats_to_metrics
-        config["statistics.interval.ms"] = 10000 # Gather metrics every 10 secs
+        config["statistics.interval.ms"] = metric_interval
 
         self.auto_commit = kwargs.get("enable.auto.commit", True)
         self.consumer = ConfluentConsumer(config)

--- a/insights_messaging/consumers/kafka.py
+++ b/insights_messaging/consumers/kafka.py
@@ -1,8 +1,10 @@
+import json
 import logging
 import os
 
 from confluent_kafka import Consumer as ConfluentConsumer
 from insights_messaging.consumers import Consumer, Requeue, archive_context_var
+from prometheus_client import Gauge
 
 log = logging.getLogger(__name__)
 
@@ -14,6 +16,59 @@ def update_archive_context_ids(payload):
         if 'id' in payload["host"]:
             payload_id_dict['inventory_id'] = payload["host"].get("id")
         archive_context_var.set(payload_id_dict)
+
+class KafkaMetrics():
+    def __init__(self):
+        self.KAFKA_CONSUMER_REBALANCE_COUNT = Gauge(
+            'kafka_consumer_rebalance_count',
+            'Number of rebalances for this consumer group',
+            labelnames=[
+                'type',
+                'client_id',
+                'state'
+            ]
+        )
+
+        self.KAFKA_CONSUMER_REBALANCE_AGE = Gauge(
+            'kafka_consumer_current_rebalance_age',
+            'Time in ms since last rebalance event',
+            labelnames=[
+                'type',
+                'client_id'
+            ]
+        )
+
+        self.KAFKA_CONSUMER_REPLY_QUEUE_SIZE = Gauge(
+            'kafka_consumer_reply_queue',
+            'Number of events waiting in poll queue',
+            labelnames=[
+                'type',
+                'client_id'
+            ]
+        )
+
+    def stats_to_metrics(self, stats_json: str) -> None:
+        stats = json.loads(stats_json)
+
+        stat_type = self.stats.get('type')
+        client_id = self.stats.get('client_id')
+
+        self.KAFKA_CONSUMER_REPLY_QUEUE_SIZE.labels(
+            type=stat_type,
+            client_id=client_id
+        ).set(self.stats.get('replyq'))
+
+        self.KAFKA_CONSUMER_REBALANCE_COUNT.labels(
+            type=stat_type,
+            client_id=client_id,
+            state=self.stats.get('cgrp').get('state')
+        ).set(self.stats.get('cgrp').get('rebalance_cnt'))
+
+        self.KAFKA_CONSUMER_REBALANCE_AGE.labels(
+            type=stat_type,
+            client_id=client_id
+        ).set(self.stats.get('cgrp').get('rebalance_age'))
+
 
 class Kafka(Consumer):
     def __init__(
@@ -29,10 +84,13 @@ class Kafka(Consumer):
     ):
 
         super().__init__(publisher, downloader, engine)
+        self.metrics_collector = KafkaMetrics()
         config = kwargs.copy()
         config["group.id"] = group_id
         config["bootstrap.servers"] = ",".join(bootstrap_servers)
         config["group.instance.id"] = kwargs.get("group.instance.id", os.environ.get("HOSTNAME"))
+        config["stats_cb"] = self.metrics_collector.stats_to_metrics
+        config["statistics.interval.ms"] = 10000 # Gather metrics every 10 secs
 
         self.auto_commit = kwargs.get("enable.auto.commit", True)
         self.consumer = ConfluentConsumer(config)

--- a/insights_messaging/consumers/kafka.py
+++ b/insights_messaging/consumers/kafka.py
@@ -50,24 +50,24 @@ class KafkaMetrics():
     def stats_to_metrics(self, stats_json: str) -> None:
         stats = json.loads(stats_json)
 
-        stat_type = self.stats.get('type')
-        client_id = self.stats.get('client_id')
+        stat_type = stats.get('type')
+        client_id = stats.get('client_id')
 
         self.KAFKA_CONSUMER_REPLY_QUEUE_SIZE.labels(
             type=stat_type,
             client_id=client_id
-        ).set(self.stats.get('replyq'))
+        ).set(stats.get('replyq'))
 
         self.KAFKA_CONSUMER_REBALANCE_COUNT.labels(
             type=stat_type,
             client_id=client_id,
-            state=self.stats.get('cgrp').get('state')
-        ).set(self.stats.get('cgrp').get('rebalance_cnt'))
+            state=stats.get('cgrp').get('state')
+        ).set(stats.get('cgrp').get('rebalance_cnt'))
 
         self.KAFKA_CONSUMER_REBALANCE_AGE.labels(
             type=stat_type,
             client_id=client_id
-        ).set(self.stats.get('cgrp').get('rebalance_age'))
+        ).set(stats.get('cgrp').get('rebalance_age'))
 
 
 class Kafka(Consumer):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ runtime = set([
     "requests",
     "s3fs",
     "retry",
-    "logstash_formatter"
+    "logstash_formatter",
+    "prometheus_client"
 ])
 
 kafka = set([


### PR DESCRIPTION
As rebalancing is a disruptive but necessary part of Kafka's ConsumerGroup functionality, keeping tabs on their frequency and effect on a Kafka consumer's operation queue size can offer extra insight into the health of the ecosystem. This attempts to configure and enable pertinent Prometheus metrics, though individual applications will need to expose those metrics to be scraped.