### PR TITLE
refactor: remove retry library

### DIFF
--- a/insights_messaging/publishers/rabbitmq.py
+++ b/insights_messaging/publishers/rabbitmq.py
@@ -1,8 +1,8 @@
 import logging
 import pika
 
-from time import time
 from . import Publisher
+from utils import retry
 
 log = logging.getLogger(__name__)
 
@@ -39,21 +39,14 @@ class RabbitMQ(Publisher):
             body=msg,
         )
 
+    @retry
     def publish(self, input_msg, response):
-        sleep_time = 1
-        while True:
-            try:
-                self.send(response)
-            except KeyboardInterrupt:
-                self.connection.close()
-            except (pika.exceptions.AMQPConnectionError, pika.exceptions.ChannelClosed) as e:
-                # Increase the sleep time by 1 second, with a max of 3 seconds per loop
-                if sleep_time < 3:
-                    sleep_time += 1
-                print(f'Caught exception {e}. Trying again in {sleep_time} seconds.')
-                time.sleep(sleep_time)
-            except pika.exceptions.ConnectionClosedByBroker:
-                break
+        try:
+            self.send(response)
+        except KeyboardInterrupt:
+            self.connection.close()
+        except pika.exceptions.ConnectionClosedByBroker:
+            pass
 
     def error(self, input_msg, ex):
         pass

--- a/insights_messaging/utils/retry.py
+++ b/insights_messaging/utils/retry.py
@@ -5,6 +5,7 @@ from time import sleep
 
 log = logging.getLogger(__name__)
 
+
 class RetryDecorator:
     def __init__(self, func: Callable[[Any], None]):
         self._func = func

--- a/insights_messaging/utils/retry.py
+++ b/insights_messaging/utils/retry.py
@@ -1,7 +1,9 @@
+import logging
 from typing import Callable, Any
 from pika.exceptions import AMPQConnectionError, ChannelClosed
 from time import sleep
 
+log = logging.getLogger(__name__)
 
 class RetryDecorator:
     def __init__(self, func: Callable[[Any], None]):
@@ -13,7 +15,7 @@ class RetryDecorator:
             try:
                 return self._func(*args, **kwargs)
             except (AMPQConnectionError, ChannelClosed) as e:
-                print(f'Caught exception {e}. Trying again in {self._sleep_time} seconds')
+                log.error(f'Caught exception {e}. Trying again in {self._sleep_time} seconds')
                 sleep(self._sleep_time)
                 if self._sleep_time < 3:
                     self._sleep_time += 1

--- a/insights_messaging/utils/retry.py
+++ b/insights_messaging/utils/retry.py
@@ -1,0 +1,23 @@
+from typing import Callable, Any
+from pika.exceptions import AMPQConnectionError, ChannelClosed
+from time import sleep
+
+
+class RetryDecorator:
+    def __init__(self, func: Callable[[Any], None]):
+        self._func = func
+        self._sleep_time = 1
+
+    def __call__(self, *args, **kwargs):
+        while True:
+            try:
+                return self._func(*args, **kwargs)
+            except (AMPQConnectionError, ChannelClosed) as e:
+                print(f'Caught exception {e}. Trying again in {self._sleep_time} seconds')
+                sleep(self._sleep_time)
+                if self._sleep_time < 3:
+                    self._sleep_time += 1
+
+
+def retry(func):
+    return RetryDecorator(func)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ runtime = set([
     "app-common-python",
     "requests",
     "s3fs",
-    "retry",
     "logstash_formatter"
 ])
 


### PR DESCRIPTION
The retry library has a dependency, py 1.11.0, that is no longer being updated for security vulnerabilities. Removing this library will help mitigate security concerns in our environment.

This change is an attempt to do what retry is doing without having to employ that library.