### PR TITLE
refactor: remove retry library (#49)

### DIFF
--- a/insights_messaging/consumers/rabbitmq.py
+++ b/insights_messaging/consumers/rabbitmq.py
@@ -1,7 +1,8 @@
 import logging
 import pika
-from retry import retry
+
 from . import Consumer, Requeue
+from utils import retry
 
 log = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ class RabbitMQ(Consumer):
     def get_url(self, input_msg):
         raise NotImplementedError()
 
-    @retry(pika.exceptions.AMQPConnectionError, delay=1, jitter=(1, 3))
+    @retry
     def run(self):
         try:
             self.open()

--- a/insights_messaging/publishers/rabbitmq.py
+++ b/insights_messaging/publishers/rabbitmq.py
@@ -1,7 +1,8 @@
 import logging
 import pika
-from retry import retry
+
 from . import Publisher
+from utils import retry
 
 log = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ class RabbitMQ(Publisher):
             body=msg,
         )
 
-    @retry(pika.exceptions.AMQPConnectionError, delay=1, jitter=(1, 3))
+    @retry
     def publish(self, input_msg, response):
         try:
             self.send(response)

--- a/insights_messaging/requeuers/rabbitmq.py
+++ b/insights_messaging/requeuers/rabbitmq.py
@@ -1,7 +1,7 @@
 import logging
 import pika
-from retry import retry
 from . import Requeuer
+from utils import retry
 
 log = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ class RabbitMQ(Requeuer):
             body=msg,
         )
 
-    @retry(pika.exceptions.AMQPConnectionError, delay=1, jitter=(1, 3))
+    @retry
     def requeue(self, msg):
         try:
             self.send(msg)

--- a/insights_messaging/utils/retry.py
+++ b/insights_messaging/utils/retry.py
@@ -1,0 +1,26 @@
+import logging
+from typing import Callable, Any
+from pika.exceptions import AMPQConnectionError, ChannelClosed
+from time import sleep
+
+log = logging.getLogger(__name__)
+
+
+class RetryDecorator:
+    def __init__(self, func: Callable[[Any], None]):
+        self._func = func
+        self._sleep_time = 1
+
+    def __call__(self, *args, **kwargs):
+        while True:
+            try:
+                return self._func(*args, **kwargs)
+            except (AMPQConnectionError, ChannelClosed) as e:
+                log.error(f'Caught exception {e}. Trying again in {self._sleep_time} seconds')
+                sleep(self._sleep_time)
+                if self._sleep_time < 3:
+                    self._sleep_time += 1
+
+
+def retry(func):
+    return RetryDecorator(func)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ runtime = set([
     "app-common-python",
     "requests",
     "s3fs",
-    "retry",
     "logstash_formatter"
 ])
 


### PR DESCRIPTION
* refactor: remove retry library

The retry library has a dependency, py 1.11.0, that is no longer being updated for security vulnerabilities. Removing this library will help mitigate security concerns in our environment.

This change is an attempt to do what retry is doing without having to employ that library.



* feat: create a retry decorator

Remove some of the repeated code from rabbit mq libraries by wrapping the functions in a decorator similar to how the retry library was doing it



* fix: Use logger instead of print for retry errors



* lint: add a line after log in retry.py



---------