### PR TITLE
Define a default value for unpacked_archive_size_limit

### DIFF
--- a/insights_messaging/appbuilder.py
+++ b/insights_messaging/appbuilder.py
@@ -94,7 +94,7 @@ class AppBuilder:
             "formatter": dr.get_component(self.service.get("format")),
             "target_components": self._get_graphs(self.service.get("target_components", [])),
             "extract_timeout": self.service.get("extract_timeout"),
-            "unpacked_archive_size_limit": self.service.get("unpacked_archive_size_limit"),
+            "unpacked_archive_size_limit": self.service.get("unpacked_archive_size_limit", None),
             "extract_tmp_dir": self.service.get("extract_tmp_dir"),
         }
 


### PR DESCRIPTION
Fixing 

```
TypeError: S3UploadEngine.__init__() got an unexpected keyword argument 'unpacked_archive_size_limit'
```

in https://github.com/RedHatInsights/insights-ccx-messaging.