### PR TITLE
Fix conversion from string to boolean

### DIFF
--- a/insights_messaging/template.py
+++ b/insights_messaging/template.py
@@ -7,7 +7,7 @@ def _infer_type(v):
         return
 
     if v.lower() in ["true", "false"]:
-        return bool(v)
+        return v.lower() == "true"
 
     for conv in [int, float]:
         try:


### PR DESCRIPTION
`_infer_type` function converts both "true" and "false" strings to `True` boolean value, which is incorrect behaviour.