### PR TITLE
[CCXDEV-15098] Add CI workflows, pre-commit config, and CODEOWNERS

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,0 +1,10 @@
+name: Linters
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  lint:
+    uses: RedHatInsights/processing-tools/.github/workflows/linters.yaml@v0.1.0

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -1,0 +1,49 @@
+name: Publish Python distribution to PyPI and TestPyPI
+
+on:
+  push:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+    - name: Install pypa/build
+      run:
+        python3 -m pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish Python distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/insights-core-messaging
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.12"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install --upgrade setuptools
+      - run: pip install --upgrade wheel
+      - run: pip install tox-gh>=1.2
+      - run: tox -vv
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        if: ${{ matrix.python-version == '3.11' }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,45 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+      - id: mixed-line-ending
+      - id: check-ast
+      - id: check-merge-conflict
+      - id: check-added-large-files
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        # Exclude checks that are commonly problematic in organization scripts
+        # SC1090: Can't follow non-constant source (dynamic sourcing)
+        # SC2086: Double quote to prevent globbing (intentional word splitting)
+        # SC2034: Variable appears unused (used by sourced scripts)
+        # SC1091: Not following included files (dynamic includes)
+        args: ['--exclude=SC1090,SC2086,SC2034,SC1091']
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.10
+    hooks:
+      - id: ruff-check
+        args:
+          - '--fix'
+          - '--line-length=100'
+          - '--select=UP,F632,E,W,F,I,N,B,C4,SIM'
+      - id: ruff-format
+
+  # - repo: https://github.com/AleksaC/hadolint-py
+  #   rev: v2.14.0
+  #   hooks:
+  #     - id: hadolint
+
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 43.113.0
+    hooks:
+      - id: renovate-config-validator

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+* @RedHatInsights/obsint-processing
+
+# Auto-merge codeowners
+pyproject.toml          @InsightsDroid @RedHatInsights/obsint-processing
+.pre-commit-config.yaml @InsightsDroid @RedHatInsights/obsint-processing
+.github/workflows/*     @InsightsDroid @RedHatInsights/obsint-processing

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+minversion = 3.18.0
+envlist = py{311,312}
+
+[testenv]
+usedevelop = True
+install_command = pip install {opts} {packages}
+extras = testing
+commands =
+    pytest -v --cov=insights_messaging --cov-branch --cov-report=term-missing
+
+[gh]
+python =
+    3.12 = py312
+    3.11 = py311


### PR DESCRIPTION
## Summary
- Add reusable linter workflow from processing-tools (matching insights-ccx-messaging pattern)
- Add tests workflow with tox across Python 3.11 and 3.12
- Add PyPI release workflow with OIDC authentication
- Add pre-commit config with ruff, shellcheck, and standard hooks
- Add CODEOWNERS for obsint-processing team
- Add tox.ini for test execution

## Test plan
- [ ] Verify linters workflow triggers on push/PR
- [ ] Verify tests workflow runs tox across Python 3.11 and 3.12
- [ ] Verify `pre-commit run --all-files` passes locally