### PR TITLE
[CCXDEV-15098] Fix broker and metrics memory leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Projects Using This Library
 Testing
 -------
 
+
 ### Test Framework
 
 The project uses [pytest](https://docs.pytest.org/) as its test

--- a/insights_messaging/consumers/__init__.py
+++ b/insights_messaging/consumers/__init__.py
@@ -65,7 +65,7 @@ class Consumer(Watched):
             raise
         finally:
             self.fire("on_consumer_complete", input_msg)
-            # CCXDEV-15098: Break circular references to prevent memory leak.
+            # Break circular references to prevent memory leak.
             #
             # When a component raises during dr.run(), Python attaches the
             # traceback to the exception via ex.__traceback__. That traceback

--- a/insights_messaging/consumers/__init__.py
+++ b/insights_messaging/consumers/__init__.py
@@ -46,6 +46,7 @@ class Consumer(Watched):
         raise NotImplementedError()
 
     def process(self, input_msg):
+        broker = None
         try:
             self.fire("on_recv", input_msg)
             url = self.get_url(input_msg)
@@ -64,6 +65,39 @@ class Consumer(Watched):
             raise
         finally:
             self.fire("on_consumer_complete", input_msg)
+            # CCXDEV-15098: Break circular references to prevent memory leak.
+            #
+            # When a component raises during dr.run(), Python attaches the
+            # traceback to the exception via ex.__traceback__. That traceback
+            # holds a reference to the stack frame, which references local
+            # variables — including the broker itself. This creates a circular
+            # reference chain:
+            #
+            #   Broker -> exceptions dict -> exception -> __traceback__
+            #          -> frame -> local vars -> Broker
+            #
+            # Because the broker's dicts keep these objects reachable, CPython's
+            # reference-counting GC cannot free them. The cyclic GC can
+            # eventually collect them, but in practice the broker and all its
+            # data (instances dict with ~500 component results) stay alive far
+            # longer than needed, causing steady memory growth (~8 MB/hr in
+            # production for rules-processing).
+            #
+            # The fix:
+            # 1. Clear ex.__traceback__ on every stored exception to sever the
+            #    frame reference. The formatted traceback string is already
+            #    saved in broker.tracebacks before this point, so no debugging
+            #    information is lost.
+            # 2. Clear the broker's large dicts (exceptions, tracebacks,
+            #    instances) so the broker object becomes lightweight and can be
+            #    collected promptly by reference counting.
+            if broker is not None:
+                for ex_list in broker.exceptions.values():
+                    for ex in ex_list:
+                        ex.__traceback__ = None
+                broker.exceptions.clear()
+                broker.tracebacks.clear()
+                broker.instances.clear()
 
     def get_url(self, input_msg):
         raise NotImplementedError()

--- a/insights_messaging/consumers/kafka.py
+++ b/insights_messaging/consumers/kafka.py
@@ -32,6 +32,26 @@ def update_archive_context_ids(payload):
 
 
 class KafkaMetrics:
+    """Prometheus metrics for Kafka consumer stats.
+
+    These metrics are populated by the confluent-kafka stats_cb callback,
+    which fires every `statistics.interval.ms` (default 10s).
+
+    CCXDEV-15098: The `state` label was intentionally removed from
+    KAFKA_CONSUMER_REBALANCE_COUNT. Previously, labelnames included
+    ['type', 'client_id', 'state'], where `state` changed over time
+    (e.g. "up", "rebalancing", "init"). Each unique label combination
+    creates a new child metric object stored permanently in
+    prometheus_client's internal `_metrics` dict — these are never
+    garbage collected. Since stats_cb fires every 10s, new label
+    combinations accumulated over time, causing ~1 MB/hr of memory
+    growth. Removing `state` from the labelnames keeps the metric
+    cardinality fixed (one child per type+client_id pair).
+
+    Consumer state is now tracked separately via KAFKA_CONSUMER_STATE,
+    which also uses fixed-cardinality labels (type + client_id only).
+    """
+
     def __init__(self, registry=None):
         """Initialize Kafka Prometheus gauges.
 
@@ -42,10 +62,20 @@ class KafkaMetrics:
                 collisions from prometheus_client's duplicate-name restriction.
         """
         gauge_kwargs = {"registry": registry} if registry else {}
+        # Rebalance count — uses fixed labels only (type + client_id).
+        # Do NOT add 'state' here; see class docstring for explanation.
         self.KAFKA_CONSUMER_REBALANCE_COUNT = Gauge(
             "kafka_consumer_rebalance_count",
             "Number of rebalances for this consumer group",
-            labelnames=["type", "client_id", "state"],
+            labelnames=["type", "client_id"],
+            **gauge_kwargs,
+        )
+
+        # Consumer state — tracked separately with fixed-cardinality labels.
+        self.KAFKA_CONSUMER_STATE = Gauge(
+            "kafka_consumer_state",
+            "Current state of the consumer group (encoded as string info label)",
+            labelnames=["type", "client_id"],
             **gauge_kwargs,
         )
 
@@ -74,7 +104,7 @@ class KafkaMetrics:
         )
 
         self.KAFKA_CONSUMER_REBALANCE_COUNT.labels(
-            type=stat_type, client_id=client_id, state=stats.get("cgrp").get("state")
+            type=stat_type, client_id=client_id
         ).set(stats.get("cgrp").get("rebalance_cnt"))
 
         self.KAFKA_CONSUMER_REBALANCE_AGE.labels(type=stat_type, client_id=client_id).set(

--- a/insights_messaging/consumers/kafka.py
+++ b/insights_messaging/consumers/kafka.py
@@ -4,7 +4,7 @@ import os
 import signal
 
 from confluent_kafka import Consumer as ConfluentConsumer
-from prometheus_client import Gauge
+from prometheus_client import Gauge, Info
 
 from insights_messaging.consumers import Consumer, RequeueError, archive_context_var
 
@@ -72,9 +72,9 @@ class KafkaMetrics:
         )
 
         # Consumer state — tracked separately with fixed-cardinality labels.
-        self.KAFKA_CONSUMER_STATE = Gauge(
+        self.KAFKA_CONSUMER_STATE = Info(
             "kafka_consumer_state",
-            "Current state of the consumer group (encoded as string info label)",
+            "Current state of the consumer group",
             labelnames=["type", "client_id"],
             **gauge_kwargs,
         )
@@ -109,6 +109,10 @@ class KafkaMetrics:
 
         self.KAFKA_CONSUMER_REBALANCE_AGE.labels(type=stat_type, client_id=client_id).set(
             stats.get("cgrp").get("rebalance_age")
+        )
+
+        self.KAFKA_CONSUMER_STATE.labels(type=stat_type, client_id=client_id).info(
+            {"state": stats.get("cgrp").get("state")}
         )
 
 

--- a/insights_messaging/consumers/kafka.py
+++ b/insights_messaging/consumers/kafka.py
@@ -37,7 +37,7 @@ class KafkaMetrics:
     These metrics are populated by the confluent-kafka stats_cb callback,
     which fires every `statistics.interval.ms` (default 10s).
 
-    CCXDEV-15098: The `state` label was intentionally removed from
+    The `state` label was intentionally removed from
     KAFKA_CONSUMER_REBALANCE_COUNT. Previously, labelnames included
     ['type', 'client_id', 'state'], where `state` changed over time
     (e.g. "up", "rebalancing", "init"). Each unique label combination
@@ -103,9 +103,9 @@ class KafkaMetrics:
             stats.get("replyq")
         )
 
-        self.KAFKA_CONSUMER_REBALANCE_COUNT.labels(
-            type=stat_type, client_id=client_id
-        ).set(stats.get("cgrp").get("rebalance_cnt"))
+        self.KAFKA_CONSUMER_REBALANCE_COUNT.labels(type=stat_type, client_id=client_id).set(
+            stats.get("cgrp").get("rebalance_cnt")
+        )
 
         self.KAFKA_CONSUMER_REBALANCE_AGE.labels(type=stat_type, client_id=client_id).set(
             stats.get("cgrp").get("rebalance_age")

--- a/insights_messaging/tests/test_kafka_metrics.py
+++ b/insights_messaging/tests/test_kafka_metrics.py
@@ -50,6 +50,25 @@ def test_stats_to_metrics_sets_gauge(kafka_metrics, gauge_attr, label_kwargs, ex
     assert sample == expected, f"{gauge_attr} should be {expected}, got {sample}"
 
 
+def test_stats_to_metrics_sets_consumer_state(kafka_metrics):
+    """stats_to_metrics must set KAFKA_CONSUMER_STATE info metric."""
+    stats = {
+        "type": "consumer",
+        "client_id": "test-client-1",
+        "cgrp": {
+            "rebalance_cnt": 1,
+            "rebalance_age": 100,
+            "state": "up",
+        },
+        "replyq": 0,
+    }
+
+    kafka_metrics.stats_to_metrics(json.dumps(stats))
+
+    info = kafka_metrics.KAFKA_CONSUMER_STATE.labels(type="consumer", client_id="test-client-1")
+    assert info._value["state"] == "up"
+
+
 def test_rebalance_count_labels_exclude_state(kafka_metrics):
     """KAFKA_CONSUMER_REBALANCE_COUNT must not include 'state' in labelnames."""
     labelnames = kafka_metrics.KAFKA_CONSUMER_REBALANCE_COUNT._labelnames

--- a/insights_messaging/tests/test_kafka_metrics.py
+++ b/insights_messaging/tests/test_kafka_metrics.py
@@ -69,37 +69,6 @@ def test_stats_to_metrics_sets_consumer_state(kafka_metrics):
     assert info._value["state"] == "up"
 
 
-def test_rebalance_count_labels_exclude_state(kafka_metrics):
-    """KAFKA_CONSUMER_REBALANCE_COUNT must not include 'state' in labelnames."""
-    labelnames = kafka_metrics.KAFKA_CONSUMER_REBALANCE_COUNT._labelnames
-
-    assert "state" not in labelnames, (
-        "KAFKA_CONSUMER_REBALANCE_COUNT should not have 'state' in its "
-        "labelnames to prevent unbounded metric cardinality growth. "
-        f"Found labelnames: {list(labelnames)}"
-    )
-    assert "type" in labelnames, "KAFKA_CONSUMER_REBALANCE_COUNT should have 'type' in labelnames"
-    assert "client_id" in labelnames, (
-        "KAFKA_CONSUMER_REBALANCE_COUNT should have 'client_id' in labelnames"
-    )
-
-
-def test_consumer_state_metric_exists(kafka_metrics):
-    """KAFKA_CONSUMER_STATE gauge must exist with type and client_id labels."""
-    assert hasattr(kafka_metrics, "KAFKA_CONSUMER_STATE"), (
-        "KafkaMetrics should have a KAFKA_CONSUMER_STATE gauge for "
-        "tracking consumer state separately from rebalance count"
-    )
-
-    labelnames = kafka_metrics.KAFKA_CONSUMER_STATE._labelnames
-    assert "type" in labelnames, "KAFKA_CONSUMER_STATE should have 'type' in labelnames"
-    assert "client_id" in labelnames, "KAFKA_CONSUMER_STATE should have 'client_id' in labelnames"
-    assert "state" not in labelnames, (
-        "KAFKA_CONSUMER_STATE should not have 'state' in labelnames — "
-        "the value is set on the gauge itself, not as a label"
-    )
-
-
 def test_metrics_cardinality_fixed_across_callbacks(kafka_metrics):
     """Metrics child count must stay constant regardless of state changes in stats callbacks."""
     # Simulate 50 stats callbacks — in production this fires every 10s

--- a/insights_messaging/tests/test_kafka_metrics.py
+++ b/insights_messaging/tests/test_kafka_metrics.py
@@ -51,17 +51,7 @@ def test_stats_to_metrics_sets_gauge(kafka_metrics, gauge_attr, label_kwargs, ex
 
 
 def test_rebalance_count_labels_exclude_state(kafka_metrics):
-    """Verify that KAFKA_CONSUMER_REBALANCE_COUNT does not include 'state'.
-
-    Previously, labelnames included ['type', 'client_id', 'state'].  Since
-    ``state`` changes over time (e.g. "up", "rebalancing", "init"), each
-    unique label combination created a new child metric object stored
-    permanently in prometheus_client's internal ``_metrics`` dict — never
-    garbage collected.  This caused ~1 MB/hr of memory growth.
-
-    The fix removes 'state' from the labelnames to keep metric cardinality
-    fixed (one child per type+client_id pair).
-    """
+    """KAFKA_CONSUMER_REBALANCE_COUNT must not include 'state' in labelnames."""
     labelnames = kafka_metrics.KAFKA_CONSUMER_REBALANCE_COUNT._labelnames
 
     assert "state" not in labelnames, (
@@ -76,12 +66,7 @@ def test_rebalance_count_labels_exclude_state(kafka_metrics):
 
 
 def test_consumer_state_metric_exists(kafka_metrics):
-    """Verify that KAFKA_CONSUMER_STATE gauge exists with correct labels.
-
-    Consumer state was previously embedded in the rebalance count metric
-    as a label, causing cardinality explosion.  It is now tracked
-    separately via KAFKA_CONSUMER_STATE with fixed-cardinality labels.
-    """
+    """KAFKA_CONSUMER_STATE gauge must exist with type and client_id labels."""
     assert hasattr(kafka_metrics, "KAFKA_CONSUMER_STATE"), (
         "KafkaMetrics should have a KAFKA_CONSUMER_STATE gauge for "
         "tracking consumer state separately from rebalance count"
@@ -97,14 +82,7 @@ def test_consumer_state_metric_exists(kafka_metrics):
 
 
 def test_metrics_cardinality_fixed_across_callbacks(kafka_metrics):
-    """Verify that metrics child count stays constant across stats callbacks.
-
-    Without the fix, each ``stats_cb`` invocation with a different ``state``
-    value would create a new child metric object in prometheus_client's
-    internal ``_metrics`` dict.  With the fix, the label set is fixed
-    (type + client_id only), so the child count should remain constant
-    regardless of how many callbacks fire.
-    """
+    """Metrics child count must stay constant regardless of state changes in stats callbacks."""
     # Simulate 50 stats callbacks — in production this fires every 10s
     for i in range(50):
         stats = {

--- a/insights_messaging/tests/test_kafka_metrics.py
+++ b/insights_messaging/tests/test_kafka_metrics.py
@@ -48,3 +48,84 @@ def test_stats_to_metrics_sets_gauge(kafka_metrics, gauge_attr, label_kwargs, ex
     gauge = getattr(kafka_metrics, gauge_attr)
     sample = gauge.labels(**label_kwargs)._value.get()
     assert sample == expected, f"{gauge_attr} should be {expected}, got {sample}"
+
+
+def test_rebalance_count_labels_exclude_state(kafka_metrics):
+    """Verify that KAFKA_CONSUMER_REBALANCE_COUNT does not include 'state'.
+
+    Previously, labelnames included ['type', 'client_id', 'state'].  Since
+    ``state`` changes over time (e.g. "up", "rebalancing", "init"), each
+    unique label combination created a new child metric object stored
+    permanently in prometheus_client's internal ``_metrics`` dict — never
+    garbage collected.  This caused ~1 MB/hr of memory growth.
+
+    The fix removes 'state' from the labelnames to keep metric cardinality
+    fixed (one child per type+client_id pair).
+    """
+    labelnames = kafka_metrics.KAFKA_CONSUMER_REBALANCE_COUNT._labelnames
+
+    assert "state" not in labelnames, (
+        "KAFKA_CONSUMER_REBALANCE_COUNT should not have 'state' in its "
+        "labelnames to prevent unbounded metric cardinality growth. "
+        f"Found labelnames: {list(labelnames)}"
+    )
+    assert "type" in labelnames, "KAFKA_CONSUMER_REBALANCE_COUNT should have 'type' in labelnames"
+    assert "client_id" in labelnames, (
+        "KAFKA_CONSUMER_REBALANCE_COUNT should have 'client_id' in labelnames"
+    )
+
+
+def test_consumer_state_metric_exists(kafka_metrics):
+    """Verify that KAFKA_CONSUMER_STATE gauge exists with correct labels.
+
+    Consumer state was previously embedded in the rebalance count metric
+    as a label, causing cardinality explosion.  It is now tracked
+    separately via KAFKA_CONSUMER_STATE with fixed-cardinality labels.
+    """
+    assert hasattr(kafka_metrics, "KAFKA_CONSUMER_STATE"), (
+        "KafkaMetrics should have a KAFKA_CONSUMER_STATE gauge for "
+        "tracking consumer state separately from rebalance count"
+    )
+
+    labelnames = kafka_metrics.KAFKA_CONSUMER_STATE._labelnames
+    assert "type" in labelnames, "KAFKA_CONSUMER_STATE should have 'type' in labelnames"
+    assert "client_id" in labelnames, "KAFKA_CONSUMER_STATE should have 'client_id' in labelnames"
+    assert "state" not in labelnames, (
+        "KAFKA_CONSUMER_STATE should not have 'state' in labelnames — "
+        "the value is set on the gauge itself, not as a label"
+    )
+
+
+def test_metrics_cardinality_fixed_across_callbacks(kafka_metrics):
+    """Verify that metrics child count stays constant across stats callbacks.
+
+    Without the fix, each ``stats_cb`` invocation with a different ``state``
+    value would create a new child metric object in prometheus_client's
+    internal ``_metrics`` dict.  With the fix, the label set is fixed
+    (type + client_id only), so the child count should remain constant
+    regardless of how many callbacks fire.
+    """
+    # Simulate 50 stats callbacks — in production this fires every 10s
+    for i in range(50):
+        stats = {
+            "type": "consumer",
+            "client_id": "test-client-memleak",
+            "cgrp": {
+                "state": ["up", "rebalancing", "init"][i % 3],
+                "rebalance_cnt": i,
+                "rebalance_age": i * 1000,
+            },
+            "replyq": 10,
+        }
+        kafka_metrics.stats_to_metrics(json.dumps(stats))
+
+    # With fixed labels, there should be exactly 1 child metric per gauge
+    # for this specific type+client_id combo.
+    rebalance_children = kafka_metrics.KAFKA_CONSUMER_REBALANCE_COUNT._metrics
+    memleak_keys = [k for k in rebalance_children if "test-client-memleak" in str(k)]
+    assert len(memleak_keys) == 1, (
+        f"Expected 1 child metric for test-client-memleak in "
+        f"KAFKA_CONSUMER_REBALANCE_COUNT, but found {len(memleak_keys)}. "
+        "This suggests 'state' or another variable label is still present, "
+        "causing unbounded cardinality growth."
+    )

--- a/insights_messaging/tests/test_kafka_metrics.py
+++ b/insights_messaging/tests/test_kafka_metrics.py
@@ -12,7 +12,7 @@ import pytest
     [
         pytest.param(
             "KAFKA_CONSUMER_REBALANCE_COUNT",
-            {"type": "consumer", "client_id": "test-client-1", "state": "up"},
+            {"type": "consumer", "client_id": "test-client-1"},
             42,
             id="rebalance_count",
         ),

--- a/insights_messaging/tests/test_memory_leak.py
+++ b/insights_messaging/tests/test_memory_leak.py
@@ -1,0 +1,567 @@
+"""
+Regression tests for CCXDEV-15098: Memory leak fixes in insights-core-messaging.
+
+This module tests two separate memory leak fixes in the messaging layer:
+
+1. **Broker cleanup in Consumer.process()** — When a component raises an
+   exception during ``dr.run()``, Python attaches the live traceback object
+   to ``exception.__traceback__``.  That traceback holds a reference to the
+   stack frame, which references local variables — including the ``broker``.
+   This creates a circular reference chain::
+
+       Broker -> exceptions -> exception -> __traceback__ -> frame -> Broker
+
+   CPython's reference-counting collector cannot break cycles, so the broker
+   and all of its data (the ``instances`` dict with ~500 component results)
+   stays alive until the cyclic GC runs.  In long-running services this
+   manifests as a steady memory leak (~8 MB/hr in production).
+
+   The fix in ``Consumer.process()`` clears ``ex.__traceback__`` on every
+   stored exception and then clears the broker's ``exceptions``,
+   ``tracebacks``, and ``instances`` dicts in the ``finally`` block,
+   breaking the cycle without losing any debugging information (the
+   formatted traceback string is already captured before cleanup).
+
+2. **Kafka metrics label cardinality** — The ``KafkaMetrics`` class
+   previously included a ``state`` label on ``KAFKA_CONSUMER_REBALANCE_COUNT``.
+   Since ``state`` changes over time (e.g. "up", "rebalancing", "init"),
+   each unique label combination created a new child metric object stored
+   permanently in prometheus_client's internal ``_metrics`` dict — never
+   garbage collected.  With ``stats_cb`` firing every 10 seconds, this
+   caused ~1 MB/hr of memory growth.
+
+   The fix removes ``state`` from the rebalance count labelnames and tracks
+   consumer state separately via ``KAFKA_CONSUMER_STATE`` with
+   fixed-cardinality labels (type + client_id only).
+
+These tests cover:
+
+- Exception ``__traceback__`` clearing after ``Consumer.process()``
+- Broker dict cleanup (exceptions, tracebacks, instances)
+- Cleanup on both success and failure paths
+- Safe handling when broker is ``None`` (download failure)
+- GC collection of brokers via reference counting alone (CPython)
+- Kafka metrics label cardinality (no ``state`` label leak)
+"""
+
+import gc
+import json
+import platform
+import traceback
+import weakref
+from collections import defaultdict
+from contextlib import contextmanager
+import pytest
+from prometheus_client import CollectorRegistry
+
+from insights_messaging.consumers import Consumer
+from insights_messaging.consumers.kafka import KafkaMetrics
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+EXPECTED_MSG = "memory leak test exception"
+EXPECTED_COMPONENT = "test_component"
+
+
+# ---------------------------------------------------------------------------
+# Mock infrastructure for Consumer.process() tests
+# ---------------------------------------------------------------------------
+
+class MockBroker:
+    """Minimal broker mock matching the attributes used by Consumer.process().
+
+    Replicates the relevant interface of ``insights.core.dr.Broker``:
+    ``exceptions`` (defaultdict(list)), ``tracebacks`` (dict), and
+    ``instances`` (dict).
+    """
+    def __init__(self):
+        self.exceptions = defaultdict(list)
+        self.tracebacks = {}
+        self.instances = {}
+
+    def add_exception(self, component, ex, tb=None):
+        """Store an exception and its formatted traceback string."""
+        self.exceptions[component].append(ex)
+        self.tracebacks[ex] = tb
+
+
+class MockPublisher:
+    """Publisher that records calls without side effects."""
+    def publish(self, input_msg, results):
+        pass
+
+    def error(self, input_msg, ex):
+        pass
+
+
+class MockEngine:
+    """Engine mock that populates the broker with exceptions.
+
+    When ``process()`` is called, it adds a test exception to the broker
+    to simulate what ``dr.run_components()`` does when a component fails.
+    The exception will have a live ``__traceback__`` (created by raising
+    and catching it), mimicking the real circular reference scenario.
+    """
+    def __init__(self, should_raise=False):
+        self.should_raise = should_raise
+
+    def process(self, broker, path):
+        # Simulate a component raising during dr.run_components().
+        # The exception gets a real __traceback__ from being raised.
+        try:
+            raise Exception(EXPECTED_MSG)
+        except Exception as ex:
+            tb = traceback.format_exc()
+            broker.add_exception(EXPECTED_COMPONENT, ex, tb)
+
+        # Also populate instances to simulate real broker state.
+        for i in range(10):
+            broker.instances[f"component_{i}"] = f"result_{i}"
+
+        if self.should_raise:
+            raise RuntimeError("engine failure")
+
+        return "test_results"
+
+
+@contextmanager
+def _mock_download():
+    """Context manager that yields a fake path, simulating downloader.get()."""
+    yield "/tmp/fake_archive"
+
+
+class MockDownloader:
+    """Downloader that returns a fake path without touching the filesystem."""
+    def get(self, url):
+        return _mock_download()
+
+
+class FailingDownloader:
+    """Downloader that raises before the broker is created.
+
+    Used to test the edge case where broker remains None in the finally block.
+    """
+    def get(self, url):
+        raise IOError("download failed")
+
+
+class StubConsumer(Consumer):
+    """Concrete Consumer subclass for testing.
+
+    Provides the minimal implementations of abstract methods (``run``,
+    ``get_url``) and exposes the broker created during ``process()`` so
+    tests can inspect it before cleanup.
+    """
+    def __init__(self, publisher, downloader, engine, broker_factory=None):
+        super().__init__(publisher, downloader, engine)
+        self._broker_factory = broker_factory or MockBroker
+        self._broker_before_cleanup = None
+
+    def run(self):
+        raise NotImplementedError()
+
+    def get_url(self, input_msg):
+        return "http://example.com/archive.tar.gz"
+
+    def create_broker(self, input_msg):
+        return self._broker_factory()
+
+
+def _find_exceptions(broker, exc_type=Exception):
+    """Return all exceptions of exc_type from any component in the broker.
+
+    Searches all components to avoid false-pass from a missed key lookup.
+    """
+    found = []
+    for comp, ex_list in broker.exceptions.items():
+        for ex in ex_list:
+            if isinstance(ex, exc_type):
+                found.append(ex)
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Helper: run process() and capture broker state before cleanup
+# ---------------------------------------------------------------------------
+
+def _run_process_capturing_broker(consumer, input_msg="test_msg"):
+    """Run consumer.process() and return the broker.
+
+    The broker's dicts are cleared in the finally block, so we capture
+    the pre-cleanup state by monkey-patching the consumer. The returned
+    broker will have cleared dicts (post-cleanup), but we store
+    pre-cleanup snapshots as attributes for assertions.
+    """
+    broker_ref = {}
+    pre_cleanup = {}
+
+    original_create = consumer.create_broker
+
+    def capturing_create(msg):
+        broker = original_create(msg)
+        broker_ref["broker"] = broker
+        return broker
+
+    consumer.create_broker = capturing_create
+
+    # Monkey-patch to capture state before cleanup
+    original_process = consumer.engine.process
+
+    def capturing_process(broker, path):
+        result = original_process(broker, path)
+        # Snapshot broker state before the finally block clears it
+        pre_cleanup["exceptions"] = {
+            comp: list(exs) for comp, exs in broker.exceptions.items()
+        }
+        pre_cleanup["tracebacks"] = dict(broker.tracebacks)
+        pre_cleanup["instances"] = dict(broker.instances)
+        return result
+
+    consumer.engine.process = capturing_process
+
+    try:
+        consumer.process(input_msg)
+    except Exception:
+        pass  # Some tests intentionally cause exceptions
+
+    broker = broker_ref.get("broker")
+    if broker is not None:
+        broker._pre_cleanup = pre_cleanup
+    return broker
+
+
+# ---------------------------------------------------------------------------
+# Tests for exception __traceback__ clearing
+# ---------------------------------------------------------------------------
+
+def test_traceback_cleared_after_process():
+    """Verify that __traceback__ is None for all exceptions after process().
+
+    Without the fix, exceptions stored in broker.exceptions retain a
+    __traceback__ reference to the stack frame, creating a circular
+    reference chain that prevents the broker from being garbage collected:
+
+        Broker -> exceptions -> ex -> __traceback__ -> frame -> Broker
+    """
+    consumer = StubConsumer(MockPublisher(), MockDownloader(), MockEngine())
+    broker = _run_process_capturing_broker(consumer)
+
+    assert broker is not None, "Broker should have been created during process()"
+
+    # Check pre-cleanup state had exceptions with tracebacks
+    pre = broker._pre_cleanup
+    all_exceptions = []
+    for ex_list in pre["exceptions"].values():
+        all_exceptions.extend(ex_list)
+
+    assert len(all_exceptions) >= 1, (
+        "Expected at least one exception in broker.exceptions before cleanup, "
+        "found none. Keys: %s" % list(pre["exceptions"].keys())
+    )
+
+    for ex in all_exceptions:
+        # The fix: __traceback__ must be cleared to break the circular ref.
+        # This happens even though broker.exceptions is also cleared,
+        # because the exception objects may be referenced elsewhere.
+        assert ex.__traceback__ is None, (
+            "ex.__traceback__ should be None after process() to prevent "
+            "circular reference: Broker -> exceptions -> ex -> "
+            "__traceback__ -> frame -> Broker"
+        )
+
+
+def test_traceback_string_preserved_before_cleanup():
+    """Verify that formatted traceback strings were captured before cleanup.
+
+    The formatted traceback string is the primary debugging artifact.
+    It must be captured in broker.tracebacks *before* the finally block
+    clears the dicts.  This test verifies no debugging information is
+    lost by the cleanup.
+    """
+    consumer = StubConsumer(MockPublisher(), MockDownloader(), MockEngine())
+    broker = _run_process_capturing_broker(consumer)
+
+    assert broker is not None, "Broker should have been created during process()"
+
+    pre = broker._pre_cleanup
+    for ex, tb_string in pre["tracebacks"].items():
+        assert tb_string is not None, (
+            "Formatted traceback string should be captured before cleanup"
+        )
+        assert EXPECTED_MSG in tb_string, (
+            "Formatted traceback should contain the exception message %r, "
+            "got: %s" % (EXPECTED_MSG, tb_string[:200])
+        )
+        assert "Traceback" in tb_string, (
+            "Formatted traceback should contain 'Traceback' header"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests for broker dict cleanup
+# ---------------------------------------------------------------------------
+
+def test_broker_dicts_cleared_after_process():
+    """Verify that broker.exceptions, tracebacks, and instances are all
+    cleared after process() completes.
+
+    Without clearing these dicts, the broker retains references to all
+    component results (~500 objects in production) and exception objects,
+    preventing them from being garbage collected even after the message
+    has been fully processed and published.
+    """
+    consumer = StubConsumer(MockPublisher(), MockDownloader(), MockEngine())
+    broker = _run_process_capturing_broker(consumer)
+
+    assert broker is not None, "Broker should have been created during process()"
+
+    # Verify pre-cleanup state had data
+    pre = broker._pre_cleanup
+    assert len(pre["exceptions"]) > 0, (
+        "Pre-cleanup broker should have had exceptions"
+    )
+    assert len(pre["instances"]) > 0, (
+        "Pre-cleanup broker should have had instances"
+    )
+
+    # Verify post-cleanup state is empty
+    assert len(broker.exceptions) == 0, (
+        "broker.exceptions should be empty after process() cleanup, "
+        "found %d entries" % len(broker.exceptions)
+    )
+    assert len(broker.tracebacks) == 0, (
+        "broker.tracebacks should be empty after process() cleanup, "
+        "found %d entries" % len(broker.tracebacks)
+    )
+    assert len(broker.instances) == 0, (
+        "broker.instances should be empty after process() cleanup, "
+        "found %d entries" % len(broker.instances)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests for cleanup on exception path
+# ---------------------------------------------------------------------------
+
+def test_cleanup_on_engine_exception():
+    """Verify that broker cleanup still happens when engine.process() raises.
+
+    The cleanup code is in the ``finally`` block, so it must execute
+    regardless of whether processing succeeds or fails.  Without this,
+    failed messages would leak the entire broker.
+    """
+    engine = MockEngine(should_raise=True)
+    consumer = StubConsumer(MockPublisher(), MockDownloader(), engine)
+
+    broker_ref = {}
+    original_create = consumer.create_broker
+
+    def capturing_create(msg):
+        broker = original_create(msg)
+        broker_ref["broker"] = broker
+        return broker
+
+    consumer.create_broker = capturing_create
+
+    with pytest.raises(RuntimeError, match="engine failure"):
+        consumer.process("test_msg")
+
+    broker = broker_ref.get("broker")
+    assert broker is not None, "Broker should have been created before engine failure"
+
+    # Even after an exception, cleanup must happen
+    assert len(broker.exceptions) == 0, (
+        "broker.exceptions should be cleared even when engine.process() raises"
+    )
+    assert len(broker.tracebacks) == 0, (
+        "broker.tracebacks should be cleared even when engine.process() raises"
+    )
+    assert len(broker.instances) == 0, (
+        "broker.instances should be cleared even when engine.process() raises"
+    )
+
+
+def test_no_crash_when_broker_is_none():
+    """Verify that process() handles the case where broker is never created.
+
+    If the download fails before create_broker() is called, broker remains
+    None.  The cleanup code in the finally block must not crash in this case.
+    """
+    consumer = StubConsumer(
+        MockPublisher(), FailingDownloader(), MockEngine()
+    )
+
+    # Should not raise — the IOError from download is caught and re-raised,
+    # but the finally block must not add a secondary exception.
+    with pytest.raises(IOError, match="download failed"):
+        consumer.process("test_msg")
+
+
+# ---------------------------------------------------------------------------
+# GC collection test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    platform.python_implementation() != "CPython",
+    reason="Relies on CPython reference-counting semantics"
+)
+def test_broker_collected_after_process():
+    """Verify that brokers are garbage collected after processing.
+
+    Without the fix, circular references from exception.__traceback__ keep
+    brokers alive indefinitely, causing memory to grow over time.
+
+    We disable the cyclic GC during the test so that only reference-counting
+    frees the brokers.  With the fix, clearing __traceback__ and the broker
+    dicts breaks all cycles and reference counting alone is sufficient.
+    Without the fix, the circular reference keeps the broker alive.
+    """
+    n_runs = 5
+    refs = []
+
+    # Disable cyclic GC so circular references are NOT collected.
+    # This makes the test deterministic: brokers survive IFF there
+    # is a reference cycle.
+    gc.collect()
+    was_enabled = gc.isenabled()
+    gc.disable()
+
+    try:
+        for _ in range(n_runs):
+            consumer = StubConsumer(
+                MockPublisher(), MockDownloader(), MockEngine()
+            )
+            # Call process() directly — don't use the capturing helper
+            # because its closures would hold extra references to the broker.
+            consumer.process("test_msg")
+            # Access the broker via the consumer's create_broker path.
+            # After process() returns, the broker local is out of scope,
+            # but we need a weakref to it.  Re-create and process to get one.
+            broker = MockBroker()
+            broker_ref = weakref.ref(broker)
+            consumer._broker_factory = lambda b=broker: b
+            consumer.process("test_msg")
+            refs.append(broker_ref)
+            del broker
+            del consumer
+
+        collected = sum(1 for ref in refs if ref() is None)
+        assert collected >= n_runs - 1, (
+            f"Only {collected}/{n_runs} brokers were garbage collected "
+            "by reference counting alone (cyclic GC disabled). "
+            "Remaining brokers are held by circular references "
+            "from exception.__traceback__ -> frame -> broker."
+        )
+    finally:
+        # Restore GC state exactly as it was before the test.
+        if was_enabled:
+            gc.enable()
+        gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# Tests for KafkaMetrics label cardinality
+# ---------------------------------------------------------------------------
+
+# Use a module-level instance to avoid prometheus_client's duplicate
+# registration error.  All Kafka metrics tests share this instance.
+_kafka_metrics = KafkaMetrics()
+
+
+def test_rebalance_count_labels_exclude_state():
+    """Verify that KAFKA_CONSUMER_REBALANCE_COUNT does not include 'state'.
+
+    Previously, labelnames included ['type', 'client_id', 'state'].  Since
+    ``state`` changes over time (e.g. "up", "rebalancing", "init"), each
+    unique label combination created a new child metric object stored
+    permanently in prometheus_client's internal ``_metrics`` dict — never
+    garbage collected.  This caused ~1 MB/hr of memory growth.
+
+    The fix removes 'state' from the labelnames to keep metric cardinality
+    fixed (one child per type+client_id pair).
+    """
+    labelnames = _kafka_metrics.KAFKA_CONSUMER_REBALANCE_COUNT._labelnames
+
+    assert "state" not in labelnames, (
+        "KAFKA_CONSUMER_REBALANCE_COUNT should not have 'state' in its "
+        "labelnames to prevent unbounded metric cardinality growth. "
+        "Found labelnames: %s" % list(labelnames)
+    )
+    assert "type" in labelnames, (
+        "KAFKA_CONSUMER_REBALANCE_COUNT should have 'type' in labelnames"
+    )
+    assert "client_id" in labelnames, (
+        "KAFKA_CONSUMER_REBALANCE_COUNT should have 'client_id' in labelnames"
+    )
+
+
+def test_consumer_state_metric_exists():
+    """Verify that KAFKA_CONSUMER_STATE gauge exists with correct labels.
+
+    Consumer state was previously embedded in the rebalance count metric
+    as a label, causing cardinality explosion.  It is now tracked
+    separately via KAFKA_CONSUMER_STATE with fixed-cardinality labels.
+    """
+    assert hasattr(_kafka_metrics, "KAFKA_CONSUMER_STATE"), (
+        "KafkaMetrics should have a KAFKA_CONSUMER_STATE gauge for "
+        "tracking consumer state separately from rebalance count"
+    )
+
+    labelnames = _kafka_metrics.KAFKA_CONSUMER_STATE._labelnames
+    assert "type" in labelnames, (
+        "KAFKA_CONSUMER_STATE should have 'type' in labelnames"
+    )
+    assert "client_id" in labelnames, (
+        "KAFKA_CONSUMER_STATE should have 'client_id' in labelnames"
+    )
+    assert "state" not in labelnames, (
+        "KAFKA_CONSUMER_STATE should not have 'state' in labelnames — "
+        "the value is set on the gauge itself, not as a label"
+    )
+
+
+def test_metrics_cardinality_fixed_across_callbacks():
+    """Verify that metrics child count stays constant across stats callbacks.
+
+    Without the fix, each ``stats_cb`` invocation with a different ``state``
+    value would create a new child metric object in prometheus_client's
+    internal ``_metrics`` dict.  With the fix, the label set is fixed
+    (type + client_id only), so the child count should remain constant
+    regardless of how many callbacks fire.
+    """
+    # Simulate 50 stats callbacks — in production this fires every 10s
+    for i in range(50):
+        stats = {
+            "type": "consumer",
+            "client_id": "test-client",
+            "cgrp": {
+                "state": ["up", "rebalancing", "init"][i % 3],
+                "rebalance_cnt": i,
+                "rebalance_age": i * 1000,
+            },
+            "replyq": 10,
+        }
+        _kafka_metrics.stats_to_metrics(json.dumps(stats))
+
+    # With fixed labels, there should be exactly 1 child metric per gauge
+    # (one for the single type+client_id combo used above).
+    rebalance_children = len(
+        _kafka_metrics.KAFKA_CONSUMER_REBALANCE_COUNT._metrics
+    )
+    assert rebalance_children == 1, (
+        f"Expected 1 child metric for KAFKA_CONSUMER_REBALANCE_COUNT "
+        f"(one per type+client_id pair), but found {rebalance_children}. "
+        "This suggests 'state' or another variable label is still present, "
+        "causing unbounded cardinality growth."
+    )
+
+    reply_children = len(
+        _kafka_metrics.KAFKA_CONSUMER_REPLY_QUEUE_SIZE._metrics
+    )
+    assert reply_children == 1, (
+        f"Expected 1 child metric for KAFKA_CONSUMER_REPLY_QUEUE_SIZE, "
+        f"but found {reply_children}."
+    )

--- a/insights_messaging/tests/test_memory_leak.py
+++ b/insights_messaging/tests/test_memory_leak.py
@@ -51,12 +51,10 @@ import traceback
 import weakref
 from collections import defaultdict
 from contextlib import contextmanager
+
 import pytest
-from prometheus_client import CollectorRegistry
 
 from insights_messaging.consumers import Consumer
-from insights_messaging.consumers.kafka import KafkaMetrics
-
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -70,6 +68,7 @@ EXPECTED_COMPONENT = "test_component"
 # Mock infrastructure for Consumer.process() tests
 # ---------------------------------------------------------------------------
 
+
 class MockBroker:
     """Minimal broker mock matching the attributes used by Consumer.process().
 
@@ -77,6 +76,7 @@ class MockBroker:
     ``exceptions`` (defaultdict(list)), ``tracebacks`` (dict), and
     ``instances`` (dict).
     """
+
     def __init__(self):
         self.exceptions = defaultdict(list)
         self.tracebacks = {}
@@ -90,6 +90,7 @@ class MockBroker:
 
 class MockPublisher:
     """Publisher that records calls without side effects."""
+
     def publish(self, input_msg, results):
         pass
 
@@ -105,6 +106,7 @@ class MockEngine:
     The exception will have a live ``__traceback__`` (created by raising
     and catching it), mimicking the real circular reference scenario.
     """
+
     def __init__(self, should_raise=False):
         self.should_raise = should_raise
 
@@ -135,6 +137,7 @@ def _mock_download():
 
 class MockDownloader:
     """Downloader that returns a fake path without touching the filesystem."""
+
     def get(self, url):
         return _mock_download()
 
@@ -144,8 +147,9 @@ class FailingDownloader:
 
     Used to test the edge case where broker remains None in the finally block.
     """
+
     def get(self, url):
-        raise IOError("download failed")
+        raise OSError("download failed")
 
 
 class StubConsumer(Consumer):
@@ -155,6 +159,7 @@ class StubConsumer(Consumer):
     ``get_url``) and exposes the broker created during ``process()`` so
     tests can inspect it before cleanup.
     """
+
     def __init__(self, publisher, downloader, engine, broker_factory=None):
         super().__init__(publisher, downloader, engine)
         self._broker_factory = broker_factory or MockBroker
@@ -176,7 +181,7 @@ def _find_exceptions(broker, exc_type=Exception):
     Searches all components to avoid false-pass from a missed key lookup.
     """
     found = []
-    for comp, ex_list in broker.exceptions.items():
+    for _comp, ex_list in broker.exceptions.items():
         for ex in ex_list:
             if isinstance(ex, exc_type):
                 found.append(ex)
@@ -186,6 +191,7 @@ def _find_exceptions(broker, exc_type=Exception):
 # ---------------------------------------------------------------------------
 # Helper: run process() and capture broker state before cleanup
 # ---------------------------------------------------------------------------
+
 
 def _run_process_capturing_broker(consumer, input_msg="test_msg"):
     """Run consumer.process() and return the broker.
@@ -213,9 +219,7 @@ def _run_process_capturing_broker(consumer, input_msg="test_msg"):
     def capturing_process(broker, path):
         result = original_process(broker, path)
         # Snapshot broker state before the finally block clears it
-        pre_cleanup["exceptions"] = {
-            comp: list(exs) for comp, exs in broker.exceptions.items()
-        }
+        pre_cleanup["exceptions"] = {comp: list(exs) for comp, exs in broker.exceptions.items()}
         pre_cleanup["tracebacks"] = dict(broker.tracebacks)
         pre_cleanup["instances"] = dict(broker.instances)
         return result
@@ -236,6 +240,7 @@ def _run_process_capturing_broker(consumer, input_msg="test_msg"):
 # ---------------------------------------------------------------------------
 # Tests for exception __traceback__ clearing
 # ---------------------------------------------------------------------------
+
 
 def test_traceback_cleared_after_process():
     """Verify that __traceback__ is None for all exceptions after process().
@@ -288,21 +293,18 @@ def test_traceback_string_preserved_before_cleanup():
 
     pre = broker._pre_cleanup
     for ex, tb_string in pre["tracebacks"].items():
-        assert tb_string is not None, (
-            "Formatted traceback string should be captured before cleanup"
-        )
+        assert tb_string is not None, "Formatted traceback string should be captured before cleanup"
         assert EXPECTED_MSG in tb_string, (
             "Formatted traceback should contain the exception message %r, "
             "got: %s" % (EXPECTED_MSG, tb_string[:200])
         )
-        assert "Traceback" in tb_string, (
-            "Formatted traceback should contain 'Traceback' header"
-        )
+        assert "Traceback" in tb_string, "Formatted traceback should contain 'Traceback' header"
 
 
 # ---------------------------------------------------------------------------
 # Tests for broker dict cleanup
 # ---------------------------------------------------------------------------
+
 
 def test_broker_dicts_cleared_after_process():
     """Verify that broker.exceptions, tracebacks, and instances are all
@@ -320,12 +322,8 @@ def test_broker_dicts_cleared_after_process():
 
     # Verify pre-cleanup state had data
     pre = broker._pre_cleanup
-    assert len(pre["exceptions"]) > 0, (
-        "Pre-cleanup broker should have had exceptions"
-    )
-    assert len(pre["instances"]) > 0, (
-        "Pre-cleanup broker should have had instances"
-    )
+    assert len(pre["exceptions"]) > 0, "Pre-cleanup broker should have had exceptions"
+    assert len(pre["instances"]) > 0, "Pre-cleanup broker should have had instances"
 
     # Verify post-cleanup state is empty
     assert len(broker.exceptions) == 0, (
@@ -345,6 +343,7 @@ def test_broker_dicts_cleared_after_process():
 # ---------------------------------------------------------------------------
 # Tests for cleanup on exception path
 # ---------------------------------------------------------------------------
+
 
 def test_cleanup_on_engine_exception():
     """Verify that broker cleanup still happens when engine.process() raises.
@@ -390,9 +389,7 @@ def test_no_crash_when_broker_is_none():
     If the download fails before create_broker() is called, broker remains
     None.  The cleanup code in the finally block must not crash in this case.
     """
-    consumer = StubConsumer(
-        MockPublisher(), FailingDownloader(), MockEngine()
-    )
+    consumer = StubConsumer(MockPublisher(), FailingDownloader(), MockEngine())
 
     # Should not raise — the IOError from download is caught and re-raised,
     # but the finally block must not add a secondary exception.
@@ -404,9 +401,10 @@ def test_no_crash_when_broker_is_none():
 # GC collection test
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.skipif(
     platform.python_implementation() != "CPython",
-    reason="Relies on CPython reference-counting semantics"
+    reason="Relies on CPython reference-counting semantics",
 )
 def test_broker_collected_after_process():
     """Verify that brokers are garbage collected after processing.
@@ -431,9 +429,7 @@ def test_broker_collected_after_process():
 
     try:
         for _ in range(n_runs):
-            consumer = StubConsumer(
-                MockPublisher(), MockDownloader(), MockEngine()
-            )
+            consumer = StubConsumer(MockPublisher(), MockDownloader(), MockEngine())
             # Call process() directly — don't use the capturing helper
             # because its closures would hold extra references to the broker.
             consumer.process("test_msg")
@@ -466,12 +462,8 @@ def test_broker_collected_after_process():
 # Tests for KafkaMetrics label cardinality
 # ---------------------------------------------------------------------------
 
-# Use a module-level instance to avoid prometheus_client's duplicate
-# registration error.  All Kafka metrics tests share this instance.
-_kafka_metrics = KafkaMetrics()
 
-
-def test_rebalance_count_labels_exclude_state():
+def test_rebalance_count_labels_exclude_state(kafka_metrics):
     """Verify that KAFKA_CONSUMER_REBALANCE_COUNT does not include 'state'.
 
     Previously, labelnames included ['type', 'client_id', 'state'].  Since
@@ -483,47 +475,41 @@ def test_rebalance_count_labels_exclude_state():
     The fix removes 'state' from the labelnames to keep metric cardinality
     fixed (one child per type+client_id pair).
     """
-    labelnames = _kafka_metrics.KAFKA_CONSUMER_REBALANCE_COUNT._labelnames
+    labelnames = kafka_metrics.KAFKA_CONSUMER_REBALANCE_COUNT._labelnames
 
     assert "state" not in labelnames, (
         "KAFKA_CONSUMER_REBALANCE_COUNT should not have 'state' in its "
         "labelnames to prevent unbounded metric cardinality growth. "
         "Found labelnames: %s" % list(labelnames)
     )
-    assert "type" in labelnames, (
-        "KAFKA_CONSUMER_REBALANCE_COUNT should have 'type' in labelnames"
-    )
+    assert "type" in labelnames, "KAFKA_CONSUMER_REBALANCE_COUNT should have 'type' in labelnames"
     assert "client_id" in labelnames, (
         "KAFKA_CONSUMER_REBALANCE_COUNT should have 'client_id' in labelnames"
     )
 
 
-def test_consumer_state_metric_exists():
+def test_consumer_state_metric_exists(kafka_metrics):
     """Verify that KAFKA_CONSUMER_STATE gauge exists with correct labels.
 
     Consumer state was previously embedded in the rebalance count metric
     as a label, causing cardinality explosion.  It is now tracked
     separately via KAFKA_CONSUMER_STATE with fixed-cardinality labels.
     """
-    assert hasattr(_kafka_metrics, "KAFKA_CONSUMER_STATE"), (
+    assert hasattr(kafka_metrics, "KAFKA_CONSUMER_STATE"), (
         "KafkaMetrics should have a KAFKA_CONSUMER_STATE gauge for "
         "tracking consumer state separately from rebalance count"
     )
 
-    labelnames = _kafka_metrics.KAFKA_CONSUMER_STATE._labelnames
-    assert "type" in labelnames, (
-        "KAFKA_CONSUMER_STATE should have 'type' in labelnames"
-    )
-    assert "client_id" in labelnames, (
-        "KAFKA_CONSUMER_STATE should have 'client_id' in labelnames"
-    )
+    labelnames = kafka_metrics.KAFKA_CONSUMER_STATE._labelnames
+    assert "type" in labelnames, "KAFKA_CONSUMER_STATE should have 'type' in labelnames"
+    assert "client_id" in labelnames, "KAFKA_CONSUMER_STATE should have 'client_id' in labelnames"
     assert "state" not in labelnames, (
         "KAFKA_CONSUMER_STATE should not have 'state' in labelnames — "
         "the value is set on the gauge itself, not as a label"
     )
 
 
-def test_metrics_cardinality_fixed_across_callbacks():
+def test_metrics_cardinality_fixed_across_callbacks(kafka_metrics):
     """Verify that metrics child count stays constant across stats callbacks.
 
     Without the fix, each ``stats_cb`` invocation with a different ``state``
@@ -536,7 +522,7 @@ def test_metrics_cardinality_fixed_across_callbacks():
     for i in range(50):
         stats = {
             "type": "consumer",
-            "client_id": "test-client",
+            "client_id": "test-client-memleak",
             "cgrp": {
                 "state": ["up", "rebalancing", "init"][i % 3],
                 "rebalance_cnt": i,
@@ -544,24 +530,15 @@ def test_metrics_cardinality_fixed_across_callbacks():
             },
             "replyq": 10,
         }
-        _kafka_metrics.stats_to_metrics(json.dumps(stats))
+        kafka_metrics.stats_to_metrics(json.dumps(stats))
 
     # With fixed labels, there should be exactly 1 child metric per gauge
-    # (one for the single type+client_id combo used above).
-    rebalance_children = len(
-        _kafka_metrics.KAFKA_CONSUMER_REBALANCE_COUNT._metrics
-    )
-    assert rebalance_children == 1, (
-        f"Expected 1 child metric for KAFKA_CONSUMER_REBALANCE_COUNT "
-        f"(one per type+client_id pair), but found {rebalance_children}. "
+    # for this specific type+client_id combo.
+    rebalance_children = kafka_metrics.KAFKA_CONSUMER_REBALANCE_COUNT._metrics
+    memleak_keys = [k for k in rebalance_children if "test-client-memleak" in str(k)]
+    assert len(memleak_keys) == 1, (
+        f"Expected 1 child metric for test-client-memleak in "
+        f"KAFKA_CONSUMER_REBALANCE_COUNT, but found {len(memleak_keys)}. "
         "This suggests 'state' or another variable label is still present, "
         "causing unbounded cardinality growth."
-    )
-
-    reply_children = len(
-        _kafka_metrics.KAFKA_CONSUMER_REPLY_QUEUE_SIZE._metrics
-    )
-    assert reply_children == 1, (
-        f"Expected 1 child metric for KAFKA_CONSUMER_REPLY_QUEUE_SIZE, "
-        f"but found {reply_children}."
     )

--- a/insights_messaging/tests/test_memory_leak.py
+++ b/insights_messaging/tests/test_memory_leak.py
@@ -22,18 +22,6 @@ This module tests two separate memory leak fixes in the messaging layer:
    breaking the cycle without losing any debugging information (the
    formatted traceback string is already captured before cleanup).
 
-2. **Kafka metrics label cardinality** — The ``KafkaMetrics`` class
-   previously included a ``state`` label on ``KAFKA_CONSUMER_REBALANCE_COUNT``.
-   Since ``state`` changes over time (e.g. "up", "rebalancing", "init"),
-   each unique label combination created a new child metric object stored
-   permanently in prometheus_client's internal ``_metrics`` dict — never
-   garbage collected.  With ``stats_cb`` firing every 10 seconds, this
-   caused ~1 MB/hr of memory growth.
-
-   The fix removes ``state`` from the rebalance count labelnames and tracks
-   consumer state separately via ``KAFKA_CONSUMER_STATE`` with
-   fixed-cardinality labels (type + client_id only).
-
 These tests cover:
 
 - Exception ``__traceback__`` clearing after ``Consumer.process()``
@@ -41,7 +29,6 @@ These tests cover:
 - Cleanup on both success and failure paths
 - Safe handling when broker is ``None`` (download failure)
 - GC collection of brokers via reference counting alone (CPython)
-- Kafka metrics label cardinality (no ``state`` label leak)
 """
 
 import gc
@@ -49,7 +36,8 @@ import platform
 import traceback
 import weakref
 from collections import defaultdict
-from contextlib import contextmanager, suppress
+from contextlib import suppress
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -64,17 +52,12 @@ EXPECTED_COMPONENT = "test_component"
 
 
 # ---------------------------------------------------------------------------
-# Mock infrastructure for Consumer.process() tests
+# Mock helpers
 # ---------------------------------------------------------------------------
 
 
 class MockBroker:
-    """Minimal broker mock matching the attributes used by Consumer.process().
-
-    Replicates the relevant interface of ``insights.core.dr.Broker``:
-    ``exceptions`` (defaultdict(list)), ``tracebacks`` (dict), and
-    ``instances`` (dict).
-    """
+    """Minimal broker mock with exceptions, tracebacks, and instances dicts."""
 
     def __init__(self):
         self.exceptions = defaultdict(list)
@@ -82,43 +65,23 @@ class MockBroker:
         self.instances = {}
 
     def add_exception(self, component, ex, tb=None):
-        """Store an exception and its formatted traceback string."""
         self.exceptions[component].append(ex)
         self.tracebacks[ex] = tb
 
 
-class MockPublisher:
-    """Publisher that records calls without side effects."""
-
-    def publish(self, input_msg, results):
-        pass
-
-    def error(self, input_msg, ex):
-        pass
-
-
 class MockEngine:
-    """Engine mock that populates the broker with exceptions.
-
-    When ``process()`` is called, it adds a test exception to the broker
-    to simulate what ``dr.run_components()`` does when a component fails.
-    The exception will have a live ``__traceback__`` (created by raising
-    and catching it), mimicking the real circular reference scenario.
-    """
+    """Engine that populates the broker with a caught exception."""
 
     def __init__(self, should_raise=False):
         self.should_raise = should_raise
 
     def process(self, broker, path):
-        # Simulate a component raising during dr.run_components().
-        # The exception gets a real __traceback__ from being raised.
         try:
             raise Exception(EXPECTED_MSG)
         except Exception as ex:
             tb = traceback.format_exc()
             broker.add_exception(EXPECTED_COMPONENT, ex, tb)
 
-        # Also populate instances to simulate real broker state.
         for i in range(10):
             broker.instances[f"component_{i}"] = f"result_{i}"
 
@@ -128,41 +91,27 @@ class MockEngine:
         return "test_results"
 
 
-@contextmanager
-def _mock_download():
-    """Context manager that yields a fake path, simulating downloader.get()."""
-    yield "/tmp/fake_archive"
+def _make_downloader():
+    """Return a MagicMock downloader whose get() yields a fake path."""
+    dl = MagicMock()
+    dl.get.return_value.__enter__ = MagicMock(return_value="/tmp/fake_archive")
+    dl.get.return_value.__exit__ = MagicMock(return_value=False)
+    return dl
 
 
-class MockDownloader:
-    """Downloader that returns a fake path without touching the filesystem."""
-
-    def get(self, url):
-        return _mock_download()
-
-
-class FailingDownloader:
-    """Downloader that raises before the broker is created.
-
-    Used to test the edge case where broker remains None in the finally block.
-    """
-
-    def get(self, url):
-        raise OSError("download failed")
+def _make_failing_downloader():
+    """Return a MagicMock downloader whose get() raises OSError."""
+    dl = MagicMock()
+    dl.get.side_effect = OSError("download failed")
+    return dl
 
 
 class StubConsumer(Consumer):
-    """Concrete Consumer subclass for testing.
-
-    Provides the minimal implementations of abstract methods (``run``,
-    ``get_url``) and exposes the broker created during ``process()`` so
-    tests can inspect it before cleanup.
-    """
+    """Concrete Consumer subclass for testing."""
 
     def __init__(self, publisher, downloader, engine, broker_factory=None):
         super().__init__(publisher, downloader, engine)
         self._broker_factory = broker_factory or MockBroker
-        self._broker_before_cleanup = None
 
     def run(self):
         raise NotImplementedError()
@@ -174,32 +123,13 @@ class StubConsumer(Consumer):
         return self._broker_factory()
 
 
-def _find_exceptions(broker, exc_type=Exception):
-    """Return all exceptions of exc_type from any component in the broker.
-
-    Searches all components to avoid false-pass from a missed key lookup.
-    """
-    found = []
-    for _comp, ex_list in broker.exceptions.items():
-        for ex in ex_list:
-            if isinstance(ex, exc_type):
-                found.append(ex)
-    return found
-
-
 # ---------------------------------------------------------------------------
 # Helper: run process() and capture broker state before cleanup
 # ---------------------------------------------------------------------------
 
 
 def _run_process_capturing_broker(consumer, input_msg="test_msg"):
-    """Run consumer.process() and return the broker.
-
-    The broker's dicts are cleared in the finally block, so we capture
-    the pre-cleanup state by monkey-patching the consumer. The returned
-    broker will have cleared dicts (post-cleanup), but we store
-    pre-cleanup snapshots as attributes for assertions.
-    """
+    """Run consumer.process() and return the broker with pre-cleanup snapshots."""
     broker_ref = {}
     pre_cleanup = {}
 
@@ -212,12 +142,10 @@ def _run_process_capturing_broker(consumer, input_msg="test_msg"):
 
     consumer.create_broker = capturing_create
 
-    # Monkey-patch to capture state before cleanup
     original_process = consumer.engine.process
 
     def capturing_process(broker, path):
         result = original_process(broker, path)
-        # Snapshot broker state before the finally block clears it
         pre_cleanup["exceptions"] = {comp: list(exs) for comp, exs in broker.exceptions.items()}
         pre_cleanup["tracebacks"] = dict(broker.tracebacks)
         pre_cleanup["instances"] = dict(broker.instances)
@@ -240,62 +168,35 @@ def _run_process_capturing_broker(consumer, input_msg="test_msg"):
 
 
 def test_traceback_cleared_after_process():
-    """Verify that __traceback__ is None for all exceptions after process().
-
-    Without the fix, exceptions stored in broker.exceptions retain a
-    __traceback__ reference to the stack frame, creating a circular
-    reference chain that prevents the broker from being garbage collected:
-
-        Broker -> exceptions -> ex -> __traceback__ -> frame -> Broker
-    """
-    consumer = StubConsumer(MockPublisher(), MockDownloader(), MockEngine())
+    """__traceback__ must be None on all stored exceptions after process()."""
+    consumer = StubConsumer(MagicMock(), _make_downloader(), MockEngine())
     broker = _run_process_capturing_broker(consumer)
 
-    assert broker is not None, "Broker should have been created during process()"
+    assert broker is not None
 
-    # Check pre-cleanup state had exceptions with tracebacks
     pre = broker._pre_cleanup
     all_exceptions = []
     for ex_list in pre["exceptions"].values():
         all_exceptions.extend(ex_list)
 
-    assert len(all_exceptions) >= 1, (
-        "Expected at least one exception in broker.exceptions before cleanup, "
-        f"found none. Keys: {list(pre['exceptions'].keys())}"
-    )
+    assert len(all_exceptions) >= 1
 
     for ex in all_exceptions:
-        # The fix: __traceback__ must be cleared to break the circular ref.
-        # This happens even though broker.exceptions is also cleared,
-        # because the exception objects may be referenced elsewhere.
-        assert ex.__traceback__ is None, (
-            "ex.__traceback__ should be None after process() to prevent "
-            "circular reference: Broker -> exceptions -> ex -> "
-            "__traceback__ -> frame -> Broker"
-        )
+        assert ex.__traceback__ is None
 
 
 def test_traceback_string_preserved_before_cleanup():
-    """Verify that formatted traceback strings were captured before cleanup.
-
-    The formatted traceback string is the primary debugging artifact.
-    It must be captured in broker.tracebacks *before* the finally block
-    clears the dicts.  This test verifies no debugging information is
-    lost by the cleanup.
-    """
-    consumer = StubConsumer(MockPublisher(), MockDownloader(), MockEngine())
+    """Formatted traceback strings must be captured before cleanup clears them."""
+    consumer = StubConsumer(MagicMock(), _make_downloader(), MockEngine())
     broker = _run_process_capturing_broker(consumer)
 
-    assert broker is not None, "Broker should have been created during process()"
+    assert broker is not None
 
     pre = broker._pre_cleanup
     for _ex, tb_string in pre["tracebacks"].items():
-        assert tb_string is not None, "Formatted traceback string should be captured before cleanup"
-        assert EXPECTED_MSG in tb_string, (
-            f"Formatted traceback should contain the exception message {EXPECTED_MSG!r}, "
-            f"got: {tb_string[:200]}"
-        )
-        assert "Traceback" in tb_string, "Formatted traceback should contain 'Traceback' header"
+        assert tb_string is not None
+        assert EXPECTED_MSG in tb_string
+        assert "Traceback" in tb_string
 
 
 # ---------------------------------------------------------------------------
@@ -304,37 +205,19 @@ def test_traceback_string_preserved_before_cleanup():
 
 
 def test_broker_dicts_cleared_after_process():
-    """Verify that broker.exceptions, tracebacks, and instances are all
-    cleared after process() completes.
-
-    Without clearing these dicts, the broker retains references to all
-    component results (~500 objects in production) and exception objects,
-    preventing them from being garbage collected even after the message
-    has been fully processed and published.
-    """
-    consumer = StubConsumer(MockPublisher(), MockDownloader(), MockEngine())
+    """broker.exceptions, tracebacks, and instances must be empty after process()."""
+    consumer = StubConsumer(MagicMock(), _make_downloader(), MockEngine())
     broker = _run_process_capturing_broker(consumer)
 
-    assert broker is not None, "Broker should have been created during process()"
+    assert broker is not None
 
-    # Verify pre-cleanup state had data
     pre = broker._pre_cleanup
-    assert len(pre["exceptions"]) > 0, "Pre-cleanup broker should have had exceptions"
-    assert len(pre["instances"]) > 0, "Pre-cleanup broker should have had instances"
+    assert len(pre["exceptions"]) > 0
+    assert len(pre["instances"]) > 0
 
-    # Verify post-cleanup state is empty
-    assert len(broker.exceptions) == 0, (
-        "broker.exceptions should be empty after process() cleanup, "
-        f"found {len(broker.exceptions)} entries"
-    )
-    assert len(broker.tracebacks) == 0, (
-        "broker.tracebacks should be empty after process() cleanup, "
-        f"found {len(broker.tracebacks)} entries"
-    )
-    assert len(broker.instances) == 0, (
-        "broker.instances should be empty after process() cleanup, "
-        f"found {len(broker.instances)} entries"
-    )
+    assert len(broker.exceptions) == 0
+    assert len(broker.tracebacks) == 0
+    assert len(broker.instances) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -343,14 +226,9 @@ def test_broker_dicts_cleared_after_process():
 
 
 def test_cleanup_on_engine_exception():
-    """Verify that broker cleanup still happens when engine.process() raises.
-
-    The cleanup code is in the ``finally`` block, so it must execute
-    regardless of whether processing succeeds or fails.  Without this,
-    failed messages would leak the entire broker.
-    """
+    """Broker cleanup must happen even when engine.process() raises."""
     engine = MockEngine(should_raise=True)
-    consumer = StubConsumer(MockPublisher(), MockDownloader(), engine)
+    consumer = StubConsumer(MagicMock(), _make_downloader(), engine)
 
     broker_ref = {}
     original_create = consumer.create_broker
@@ -366,31 +244,18 @@ def test_cleanup_on_engine_exception():
         consumer.process("test_msg")
 
     broker = broker_ref.get("broker")
-    assert broker is not None, "Broker should have been created before engine failure"
+    assert broker is not None
 
-    # Even after an exception, cleanup must happen
-    assert len(broker.exceptions) == 0, (
-        "broker.exceptions should be cleared even when engine.process() raises"
-    )
-    assert len(broker.tracebacks) == 0, (
-        "broker.tracebacks should be cleared even when engine.process() raises"
-    )
-    assert len(broker.instances) == 0, (
-        "broker.instances should be cleared even when engine.process() raises"
-    )
+    assert len(broker.exceptions) == 0
+    assert len(broker.tracebacks) == 0
+    assert len(broker.instances) == 0
 
 
 def test_no_crash_when_broker_is_none():
-    """Verify that process() handles the case where broker is never created.
+    """process() must not crash in the finally block when broker is None."""
+    consumer = StubConsumer(MagicMock(), _make_failing_downloader(), MockEngine())
 
-    If the download fails before create_broker() is called, broker remains
-    None.  The cleanup code in the finally block must not crash in this case.
-    """
-    consumer = StubConsumer(MockPublisher(), FailingDownloader(), MockEngine())
-
-    # Should not raise — the IOError from download is caught and re-raised,
-    # but the finally block must not add a secondary exception.
-    with pytest.raises(IOError, match="download failed"):
+    with pytest.raises(OSError, match="download failed"):
         consumer.process("test_msg")
 
 
@@ -404,35 +269,18 @@ def test_no_crash_when_broker_is_none():
     reason="Relies on CPython reference-counting semantics",
 )
 def test_broker_collected_after_process():
-    """Verify that brokers are garbage collected after processing.
-
-    Without the fix, circular references from exception.__traceback__ keep
-    brokers alive indefinitely, causing memory to grow over time.
-
-    We disable the cyclic GC during the test so that only reference-counting
-    frees the brokers.  With the fix, clearing __traceback__ and the broker
-    dicts breaks all cycles and reference counting alone is sufficient.
-    Without the fix, the circular reference keeps the broker alive.
-    """
+    """Brokers must be GC-collectible by refcounting alone (no cyclic GC needed)."""
     n_runs = 5
     refs = []
 
-    # Disable cyclic GC so circular references are NOT collected.
-    # This makes the test deterministic: brokers survive IFF there
-    # is a reference cycle.
     gc.collect()
     was_enabled = gc.isenabled()
     gc.disable()
 
     try:
         for _ in range(n_runs):
-            consumer = StubConsumer(MockPublisher(), MockDownloader(), MockEngine())
-            # Call process() directly — don't use the capturing helper
-            # because its closures would hold extra references to the broker.
+            consumer = StubConsumer(MagicMock(), _make_downloader(), MockEngine())
             consumer.process("test_msg")
-            # Access the broker via the consumer's create_broker path.
-            # After process() returns, the broker local is out of scope,
-            # but we need a weakref to it.  Re-create and process to get one.
             broker = MockBroker()
             broker_ref = weakref.ref(broker)
             consumer._broker_factory = lambda b=broker: b
@@ -443,13 +291,9 @@ def test_broker_collected_after_process():
 
         collected = sum(1 for ref in refs if ref() is None)
         assert collected >= n_runs - 1, (
-            f"Only {collected}/{n_runs} brokers were garbage collected "
-            "by reference counting alone (cyclic GC disabled). "
-            "Remaining brokers are held by circular references "
-            "from exception.__traceback__ -> frame -> broker."
+            f"Only {collected}/{n_runs} brokers were collected by refcounting alone"
         )
     finally:
-        # Restore GC state exactly as it was before the test.
         if was_enabled:
             gc.enable()
         gc.collect()

--- a/insights_messaging/tests/test_memory_leak.py
+++ b/insights_messaging/tests/test_memory_leak.py
@@ -45,7 +45,6 @@ These tests cover:
 """
 
 import gc
-import json
 import platform
 import traceback
 import weakref
@@ -454,89 +453,3 @@ def test_broker_collected_after_process():
         if was_enabled:
             gc.enable()
         gc.collect()
-
-
-# ---------------------------------------------------------------------------
-# Tests for KafkaMetrics label cardinality
-# ---------------------------------------------------------------------------
-
-
-def test_rebalance_count_labels_exclude_state(kafka_metrics):
-    """Verify that KAFKA_CONSUMER_REBALANCE_COUNT does not include 'state'.
-
-    Previously, labelnames included ['type', 'client_id', 'state'].  Since
-    ``state`` changes over time (e.g. "up", "rebalancing", "init"), each
-    unique label combination created a new child metric object stored
-    permanently in prometheus_client's internal ``_metrics`` dict — never
-    garbage collected.  This caused ~1 MB/hr of memory growth.
-
-    The fix removes 'state' from the labelnames to keep metric cardinality
-    fixed (one child per type+client_id pair).
-    """
-    labelnames = kafka_metrics.KAFKA_CONSUMER_REBALANCE_COUNT._labelnames
-
-    assert "state" not in labelnames, (
-        "KAFKA_CONSUMER_REBALANCE_COUNT should not have 'state' in its "
-        "labelnames to prevent unbounded metric cardinality growth. "
-        f"Found labelnames: {list(labelnames)}"
-    )
-    assert "type" in labelnames, "KAFKA_CONSUMER_REBALANCE_COUNT should have 'type' in labelnames"
-    assert "client_id" in labelnames, (
-        "KAFKA_CONSUMER_REBALANCE_COUNT should have 'client_id' in labelnames"
-    )
-
-
-def test_consumer_state_metric_exists(kafka_metrics):
-    """Verify that KAFKA_CONSUMER_STATE gauge exists with correct labels.
-
-    Consumer state was previously embedded in the rebalance count metric
-    as a label, causing cardinality explosion.  It is now tracked
-    separately via KAFKA_CONSUMER_STATE with fixed-cardinality labels.
-    """
-    assert hasattr(kafka_metrics, "KAFKA_CONSUMER_STATE"), (
-        "KafkaMetrics should have a KAFKA_CONSUMER_STATE gauge for "
-        "tracking consumer state separately from rebalance count"
-    )
-
-    labelnames = kafka_metrics.KAFKA_CONSUMER_STATE._labelnames
-    assert "type" in labelnames, "KAFKA_CONSUMER_STATE should have 'type' in labelnames"
-    assert "client_id" in labelnames, "KAFKA_CONSUMER_STATE should have 'client_id' in labelnames"
-    assert "state" not in labelnames, (
-        "KAFKA_CONSUMER_STATE should not have 'state' in labelnames — "
-        "the value is set on the gauge itself, not as a label"
-    )
-
-
-def test_metrics_cardinality_fixed_across_callbacks(kafka_metrics):
-    """Verify that metrics child count stays constant across stats callbacks.
-
-    Without the fix, each ``stats_cb`` invocation with a different ``state``
-    value would create a new child metric object in prometheus_client's
-    internal ``_metrics`` dict.  With the fix, the label set is fixed
-    (type + client_id only), so the child count should remain constant
-    regardless of how many callbacks fire.
-    """
-    # Simulate 50 stats callbacks — in production this fires every 10s
-    for i in range(50):
-        stats = {
-            "type": "consumer",
-            "client_id": "test-client-memleak",
-            "cgrp": {
-                "state": ["up", "rebalancing", "init"][i % 3],
-                "rebalance_cnt": i,
-                "rebalance_age": i * 1000,
-            },
-            "replyq": 10,
-        }
-        kafka_metrics.stats_to_metrics(json.dumps(stats))
-
-    # With fixed labels, there should be exactly 1 child metric per gauge
-    # for this specific type+client_id combo.
-    rebalance_children = kafka_metrics.KAFKA_CONSUMER_REBALANCE_COUNT._metrics
-    memleak_keys = [k for k in rebalance_children if "test-client-memleak" in str(k)]
-    assert len(memleak_keys) == 1, (
-        f"Expected 1 child metric for test-client-memleak in "
-        f"KAFKA_CONSUMER_REBALANCE_COUNT, but found {len(memleak_keys)}. "
-        "This suggests 'state' or another variable label is still present, "
-        "causing unbounded cardinality growth."
-    )

--- a/insights_messaging/tests/test_memory_leak.py
+++ b/insights_messaging/tests/test_memory_leak.py
@@ -137,58 +137,31 @@ def _run_process_capturing_broker(consumer, input_msg="test_msg"):
 
 
 # ---------------------------------------------------------------------------
-# Tests for exception __traceback__ clearing
+# Tests for broker cleanup after process()
 # ---------------------------------------------------------------------------
 
 
-def test_traceback_cleared_after_process():
-    """__traceback__ must be None on all stored exceptions after process()."""
+def test_broker_cleanup_after_process():
+    """Broker dicts and exception tracebacks must be cleaned up after process()."""
     consumer = StubConsumer(MagicMock(), _make_downloader(), MockEngine())
     broker = _run_process_capturing_broker(consumer)
 
     assert broker is not None
 
     pre = broker._pre_cleanup
-    all_exceptions = []
-    for ex_list in pre["exceptions"].values():
-        all_exceptions.extend(ex_list)
 
-    assert len(all_exceptions) >= 1
-
-    for ex in all_exceptions:
-        assert ex.__traceback__ is None
-
-
-def test_traceback_string_preserved_before_cleanup():
-    """Formatted traceback strings must be captured before cleanup clears them."""
-    consumer = StubConsumer(MagicMock(), _make_downloader(), MockEngine())
-    broker = _run_process_capturing_broker(consumer)
-
-    assert broker is not None
-
-    pre = broker._pre_cleanup
+    # Traceback strings were captured before cleanup
     for _ex, tb_string in pre["tracebacks"].items():
         assert tb_string is not None
         assert EXPECTED_MSG in tb_string
-        assert "Traceback" in tb_string
 
+    # __traceback__ cleared on all stored exceptions
+    all_exceptions = [ex for exs in pre["exceptions"].values() for ex in exs]
+    assert len(all_exceptions) >= 1
+    for ex in all_exceptions:
+        assert ex.__traceback__ is None
 
-# ---------------------------------------------------------------------------
-# Tests for broker dict cleanup
-# ---------------------------------------------------------------------------
-
-
-def test_broker_dicts_cleared_after_process():
-    """broker.exceptions, tracebacks, and instances must be empty after process()."""
-    consumer = StubConsumer(MagicMock(), _make_downloader(), MockEngine())
-    broker = _run_process_capturing_broker(consumer)
-
-    assert broker is not None
-
-    pre = broker._pre_cleanup
-    assert len(pre["exceptions"]) > 0
-    assert len(pre["instances"]) > 0
-
+    # Broker dicts emptied
     assert len(broker.exceptions) == 0
     assert len(broker.tracebacks) == 0
     assert len(broker.instances) == 0

--- a/insights_messaging/tests/test_memory_leak.py
+++ b/insights_messaging/tests/test_memory_leak.py
@@ -1,5 +1,5 @@
 """
-Regression tests for CCXDEV-15098: Memory leak fixes in insights-core-messaging.
+Regression tests for memory leak fixes in insights-core-messaging.
 
 This module tests two separate memory leak fixes in the messaging layer:
 
@@ -50,7 +50,7 @@ import platform
 import traceback
 import weakref
 from collections import defaultdict
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 
 import pytest
 
@@ -226,10 +226,8 @@ def _run_process_capturing_broker(consumer, input_msg="test_msg"):
 
     consumer.engine.process = capturing_process
 
-    try:
+    with suppress(Exception):
         consumer.process(input_msg)
-    except Exception:
-        pass  # Some tests intentionally cause exceptions
 
     broker = broker_ref.get("broker")
     if broker is not None:
@@ -264,7 +262,7 @@ def test_traceback_cleared_after_process():
 
     assert len(all_exceptions) >= 1, (
         "Expected at least one exception in broker.exceptions before cleanup, "
-        "found none. Keys: %s" % list(pre["exceptions"].keys())
+        f"found none. Keys: {list(pre['exceptions'].keys())}"
     )
 
     for ex in all_exceptions:
@@ -292,11 +290,11 @@ def test_traceback_string_preserved_before_cleanup():
     assert broker is not None, "Broker should have been created during process()"
 
     pre = broker._pre_cleanup
-    for ex, tb_string in pre["tracebacks"].items():
+    for _ex, tb_string in pre["tracebacks"].items():
         assert tb_string is not None, "Formatted traceback string should be captured before cleanup"
         assert EXPECTED_MSG in tb_string, (
-            "Formatted traceback should contain the exception message %r, "
-            "got: %s" % (EXPECTED_MSG, tb_string[:200])
+            f"Formatted traceback should contain the exception message {EXPECTED_MSG!r}, "
+            f"got: {tb_string[:200]}"
         )
         assert "Traceback" in tb_string, "Formatted traceback should contain 'Traceback' header"
 
@@ -328,15 +326,15 @@ def test_broker_dicts_cleared_after_process():
     # Verify post-cleanup state is empty
     assert len(broker.exceptions) == 0, (
         "broker.exceptions should be empty after process() cleanup, "
-        "found %d entries" % len(broker.exceptions)
+        f"found {len(broker.exceptions)} entries"
     )
     assert len(broker.tracebacks) == 0, (
         "broker.tracebacks should be empty after process() cleanup, "
-        "found %d entries" % len(broker.tracebacks)
+        f"found {len(broker.tracebacks)} entries"
     )
     assert len(broker.instances) == 0, (
         "broker.instances should be empty after process() cleanup, "
-        "found %d entries" % len(broker.instances)
+        f"found {len(broker.instances)} entries"
     )
 
 
@@ -480,7 +478,7 @@ def test_rebalance_count_labels_exclude_state(kafka_metrics):
     assert "state" not in labelnames, (
         "KAFKA_CONSUMER_REBALANCE_COUNT should not have 'state' in its "
         "labelnames to prevent unbounded metric cardinality growth. "
-        "Found labelnames: %s" % list(labelnames)
+        f"Found labelnames: {list(labelnames)}"
     )
     assert "type" in labelnames, "KAFKA_CONSUMER_REBALANCE_COUNT should have 'type' in labelnames"
     assert "client_id" in labelnames, (

--- a/insights_messaging/tests/test_memory_leak.py
+++ b/insights_messaging/tests/test_memory_leak.py
@@ -1,34 +1,8 @@
 """
-Regression tests for memory leak fixes in insights-core-messaging.
+Tests for broker memory leak fixes in Consumer.process().
 
-This module tests two separate memory leak fixes in the messaging layer:
-
-1. **Broker cleanup in Consumer.process()** — When a component raises an
-   exception during ``dr.run()``, Python attaches the live traceback object
-   to ``exception.__traceback__``.  That traceback holds a reference to the
-   stack frame, which references local variables — including the ``broker``.
-   This creates a circular reference chain::
-
-       Broker -> exceptions -> exception -> __traceback__ -> frame -> Broker
-
-   CPython's reference-counting collector cannot break cycles, so the broker
-   and all of its data (the ``instances`` dict with ~500 component results)
-   stays alive until the cyclic GC runs.  In long-running services this
-   manifests as a steady memory leak (~8 MB/hr in production).
-
-   The fix in ``Consumer.process()`` clears ``ex.__traceback__`` on every
-   stored exception and then clears the broker's ``exceptions``,
-   ``tracebacks``, and ``instances`` dicts in the ``finally`` block,
-   breaking the cycle without losing any debugging information (the
-   formatted traceback string is already captured before cleanup).
-
-These tests cover:
-
-- Exception ``__traceback__`` clearing after ``Consumer.process()``
-- Broker dict cleanup (exceptions, tracebacks, instances)
-- Cleanup on both success and failure paths
-- Safe handling when broker is ``None`` (download failure)
-- GC collection of brokers via reference counting alone (CPython)
+Covers traceback clearing, broker dict cleanup, safe handling when
+broker is None, and GC collection via reference counting.
 """
 
 import gc


### PR DESCRIPTION
## Summary

- Fix memory leak caused by circular reference: `Broker -> exceptions -> ex -> __traceback__ -> frame -> Broker`. Clear `__traceback__` on exception objects and broker dicts after processing.
- Remove `state` label from `KAFKA_CONSUMER_REBALANCE_COUNT` to prevent unbounded metric cardinality growth (~1 MB/hr). Track consumer state separately via `KAFKA_CONSUMER_STATE`.
- Add unit tests for the memory leak fix and metric cardinality fix.

## Dependencies

Depends on #77 (unit tests and pyproject.toml migration).

## Test plan

- [ ] Verify `tox -vv` passes for Python 3.11 and 3.12
- [ ] Verify broker dicts are cleared after `process()` completes
- [ ] Verify `KAFKA_CONSUMER_REBALANCE_COUNT` no longer includes `state` label